### PR TITLE
Enabled build limits up to 512.

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -81,6 +81,7 @@ import ganymedes01.etfuturum.recipes.SmithingTableRecipes;
 import ganymedes01.etfuturum.spectator.SpectatorMode;
 import ganymedes01.etfuturum.world.EtFuturumLateWorldGenerator;
 import ganymedes01.etfuturum.world.EtFuturumWorldGenerator;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
 import ganymedes01.etfuturum.world.end.dimension.DimensionProviderEFREnd;
 import ganymedes01.etfuturum.world.nether.biome.utils.NetherBiomeManager;
 import ganymedes01.etfuturum.world.nether.dimension.DimensionProviderEFRNether;
@@ -112,6 +113,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.WeightedRandomChestContent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ChestGenHooks;
@@ -147,6 +149,8 @@ public class EtFuturum {
 	public static CommonProxy proxy;
 
 	public static SimpleNetworkWrapper networkWrapper;
+
+	public static final String githubURL = "https://github.com/Roadhog360/Et-Futurum-Requiem";
 
 	public static CreativeTabs creativeTabItems = new CreativeTabs(MOD_ID + ".items") {
 		@Override
@@ -235,6 +239,9 @@ public class EtFuturum {
 	@EventHandler
 	@SuppressWarnings("unchecked")
 	public void preInit(FMLPreInitializationEvent event) {
+
+		WorldHeightHandler.initWorldHeightHandler();
+
 		try {
 			Field chestInfo = ChestGenHooks.class.getDeclaredField("chestInfo");
 			chestInfo.setAccessible(true);
@@ -655,6 +662,13 @@ public class EtFuturum {
 
 	@EventHandler
 	public void serverStarting(FMLServerStartingEvent event) {
+
+		if (WorldHeightHandler.isIncreasedWorldHeightEnabled()) {
+
+			MinecraftServer server = event.getServer();
+			server.setBuildLimit(WorldHeightHandler.getMaxWorldHeight());
+		}
+
 		if (ConfigFunctions.enableFillCommand) {
 			event.registerServerCommand(new CommandFill());
 		}

--- a/src/main/java/ganymedes01/etfuturum/EtFuturumContainer.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturumContainer.java
@@ -1,0 +1,158 @@
+package ganymedes01.etfuturum;
+
+import com.google.common.eventbus.EventBus;
+import cpw.mods.fml.common.*;
+import ganymedes01.etfuturum.lib.Reference;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import ganymedes01.etfuturum.world.WorldHeightHandler.NBTTags;
+import ganymedes01.etfuturum.world.WorldHeightHandler.WorldHeightMigrator;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.world.storage.WorldInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class EtFuturumContainer extends InjectedModContainer implements WorldAccessContainer {
+
+    // This is needed because for whatever reason minecraft creates a lot of different WorldInfo objects so worldinfo.getAdditionalProperty returns null in getDataForWriting()
+    // Strangely enough this happens only on servers, not in singleplayer
+    private NBTTagCompound etfuturumNBT = new NBTTagCompound();
+
+    public EtFuturumContainer() {
+
+        super(new DummyModContainer(getDummyMetadata()), null);
+    }
+
+    private static ModMetadata getDummyMetadata() {
+
+        ModMetadata metadata = new ModMetadata();
+
+        metadata.modId = Reference.MOD_CONTAINER_ID;
+        metadata.name = Reference.MOD_CONTAINER_NAME;
+        metadata.version = Reference.VERSION_NUMBER;
+
+        return metadata;
+    }
+
+    @Override
+    public boolean registerBus(EventBus bus, LoadController controller) {
+
+        bus.register(this);
+
+        return true;
+    }
+
+    //This gets triggered at world saving to write nbt tags into level.dat
+    @Override
+    public NBTTagCompound getDataForWriting(SaveHandler handler, WorldInfo info) {
+
+        // Hopefully this a valid indicator for a newly generated world
+        if (!etfuturumNBT.hasKey(NBTTags.MOD_VERSION.toString()) && WorldHeightHandler.isIncreasedWorldHeightEnabled()) {
+
+            etfuturumNBT.setString(NBTTags.MOD_VERSION.toString(), Tags.VERSION);
+            etfuturumNBT.setBoolean(WorldHeightHandler.NBTTags.HEIGHT_ENABLED.toString(), true);
+            etfuturumNBT.setBoolean(WorldHeightHandler.NBTTags.HEIGHT_NATURALLY.toString(), true);
+            etfuturumNBT.setInteger(WorldHeightHandler.NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+        }
+
+        return etfuturumNBT == null ? new NBTTagCompound() : (NBTTagCompound) etfuturumNBT.copy();
+    }
+
+    //This gets triggered at world load to read the level.dat nbt tags
+    @Override
+    public void readData(SaveHandler handler, WorldInfo info, Map<String, NBTBase> propertyMap, NBTTagCompound nbt) {
+
+        // Sets the variable to the nbt from current world
+        etfuturumNBT = nbt;
+
+        if (!etfuturumNBT.getString(NBTTags.MOD_VERSION.toString()).equals(Tags.VERSION)) {
+
+            etfuturumNBT.setString(NBTTags.MOD_VERSION.toString(), Tags.VERSION);
+        }
+
+        int migrationFlag = WorldHeightMigrator.isMigrationNeeded(etfuturumNBT);
+        String confirmText;
+        boolean confirmMigration;
+
+        switch (migrationFlag) {
+            case 1:
+                confirmText = String.format("""
+                        ######################################################################################################################################################
+                        [World Height Migration] You have %s installed and enabled the Increase World Height feature with an height offset %s set for existing worlds.
+                        [World Height Migration] That means your complete world will be shifted up by this offset.
+                        [World Height Migration] This can serve various purposes i.e. its necessary to use the deep dark caves feature.
+                        [World Height Migration] This feature is experimental so please make a backup of your world (we will also make one for you but better have it twice).
+                        [World Height Migration] Are you sure that you want to migrate the world?
+                        ######################################################################################################################################################""", Reference.MOD_NAME, WorldHeightHandler.getWorldHeightOffset());
+                confirmMigration = StartupQuery.confirm(confirmText);
+                if (!confirmMigration) { StartupQuery.abort(); }
+                migrateWorld(handler.getWorldDirectory(), etfuturumNBT, info);
+                break;
+            case 2:
+                confirmText = String.format("""
+                        ######################################################################################################################################################
+                        [World Height Migration] You have %s installed and enabled the Increase World Height feature with an height offset %s set for existing worlds.
+                        [World Height Migration] That means your complete world will be completely shifted down by this offset.
+                        [World Height Migration] Keep in mind that every block below Y:%s gets destroyed.
+                        [World Height Migration] This feature is experimental so please make a backup of your world (we will also make one for you but better have it twice).
+                        ######################################################################################################################################################""", Reference.MOD_NAME, WorldHeightHandler.getWorldHeightOffset(), Math.abs(WorldHeightHandler.getWorldHeightOffset()));
+                confirmMigration = StartupQuery.confirm(confirmText);
+                if (!confirmMigration) { StartupQuery.abort(); }
+                migrateWorld(handler.getWorldDirectory(), etfuturumNBT, info);
+                break;
+            case 3:
+                confirmText = String.format("""
+                        ############################################################################################################################################################
+                        [World Height Migration] You have %s installed and enabled the Increase World Height feature with an max world height set to %s.
+                        [World Height Migration] But you want to load a world with max world height of %s.
+                        [World Height Migration] Everything above Y:%s gets destroyed. Please make a backup of your world (we will also make one for you but better have it twice).
+                        [World Height Migration] Are you sure that you want to migrate the world?
+                        ############################################################################################################################################################""", Reference.MOD_NAME, WorldHeightHandler.getMaxWorldHeight(), etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString()), etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString()));
+                confirmMigration = StartupQuery.confirm(confirmText);
+                if (!confirmMigration) { StartupQuery.abort(); }
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), WorldHeightHandler.isIncreasedWorldHeightEnabled());
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+                break;
+            case 4:
+                confirmText = String.format("""
+                        ##################################################################################################################################
+                        [World Height Migration] You have disabled the Increase World Height feature but want to load a world
+                        [World Height Migration] with Increased World Height enabled and a max world height of %s. Everything above Y:256 gets destroyed.
+                        [World Height Migration] Please make a backup of your world (we will also make one for you but better have it twice).
+                        ##################################################################################################################################""", etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString()));
+                confirmMigration = StartupQuery.confirm(confirmText);
+                if(!confirmMigration) { StartupQuery.abort(); }
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), false);
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), 256);
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_MIGRATED.toString(), false);
+                etfuturumNBT.setInteger(NBTTags.HEIGHT_OFFSET.toString(), 0);
+            default:
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), WorldHeightHandler.isIncreasedWorldHeightEnabled());
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+                break;
+        }
+    }
+
+    private static void migrateWorld(File worldDir, NBTTagCompound etfuturumNBT, WorldInfo info) {
+
+        try {
+
+            WorldHeightMigrator.migrateWorldHeight(worldDir);
+
+            etfuturumNBT.setBoolean(WorldHeightHandler.NBTTags.HEIGHT_ENABLED.toString(), true);
+            etfuturumNBT.setInteger(WorldHeightHandler.NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+            etfuturumNBT.setBoolean(WorldHeightHandler.NBTTags.HEIGHT_MIGRATED.toString(), true);
+            etfuturumNBT.setInteger(WorldHeightHandler.NBTTags.HEIGHT_OFFSET.toString(), WorldHeightHandler.getWorldHeightOffset());
+
+            info.setSpawnPosition(info.getSpawnX(), info.getSpawnY() + WorldHeightHandler.getWorldHeightOffset(), info.getSpawnZ());
+
+        } catch (IOException e) {
+
+            StartupQuery.notify("[World Height Migration] The migration is failed! World load gets aborted.");
+            StartupQuery.abort();
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightConfirmDisabling.java
+++ b/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightConfirmDisabling.java
@@ -1,0 +1,137 @@
+package ganymedes01.etfuturum.client.gui;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.client.GuiBackupFailed;
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import cpw.mods.fml.common.ZipperUtil;
+import ganymedes01.etfuturum.Tags;
+import ganymedes01.etfuturum.core.utils.helpers.NBTHelper;
+import ganymedes01.etfuturum.lib.Reference;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import ganymedes01.etfuturum.world.WorldHeightHandler.NBTTags;
+import net.minecraft.client.gui.*;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
+import org.apache.logging.log4j.Level;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class GuiWorldHeightConfirmDisabling extends GuiYesNo implements GuiYesNoCallback {
+
+    private GuiSelectWorld parent;
+    private String description;
+    private File worldDir;
+    private String saveName;
+    private File backupZip;
+
+    public GuiWorldHeightConfirmDisabling(GuiYesNoCallback parent, String title, String description, File worldDir, String saveName) {
+
+        super(parent, title, description, StatCollector.translateToLocal("gui.load_world"), StatCollector.translateToLocal("gui.toMenu"),0);
+
+        this.parent = (GuiSelectWorld) parent;
+        this.description = description;
+        this.worldDir = worldDir;
+        this.saveName = saveName;
+        this.backupZip = new File(FMLClientHandler.instance().getSavesDirectory(),String.format("%s-%2$td%2$tm%2$ty%2$tH%2$tM%2$tS.zip", worldDir.getName(), System.currentTimeMillis()));
+    }
+
+    @Override
+    public void initGui() {
+
+        this.buttonList.add(new GuiOptionButton(0, this.width / 2 - 155, this.height / 6 * 5 , this.confirmButtonText));
+        this.buttonList.add(new GuiOptionButton(1, this.width / 2 - 155 + 160, this.height / 6 * 5, this.cancelButtonText));
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+
+        this.drawDefaultBackground();
+
+        int y = this.height / 6;
+
+        this.drawCenteredString(this.fontRendererObj, this.field_146351_f, this.width / 2, y - 20, 16777215);
+
+        y += 20;
+
+        List<String> lines = fontRendererObj.listFormattedStringToWidth(description, this.width - 50);
+
+        for (String descriptionLine : lines) {
+
+            this.drawCenteredString(this.fontRendererObj, descriptionLine, this.width / 2, y, 16777215);
+
+            y += 17;
+        }
+
+        for (GuiButton guiButton : this.buttonList) {
+
+            ((GuiButton) guiButton).drawButton(this.mc, mouseX, mouseY);
+        }
+
+        for (GuiLabel guiLabel : this.labelList) {
+
+            ((GuiLabel) guiLabel).func_146159_a(this.mc, mouseX, mouseY);
+        }
+    }
+
+    @Override
+    protected void actionPerformed(GuiButton button) {
+
+        if (button.id == 0) {
+
+            // Creating a backup
+
+            FMLLog.info("Creating a backup of world %s into file %s", saveName, backupZip.getAbsolutePath());
+
+            try {
+
+                ZipperUtil.zip(worldDir, backupZip);
+
+            } catch (IOException e) {
+
+                FMLLog.log(Level.WARN, e, "There was a problem saving the backup %s. Please fix and try again", backupZip.getName());
+                FMLClientHandler.instance().showGuiScreen(new GuiBackupFailed(parent, backupZip));
+
+                return;
+            }
+
+            FMLClientHandler.instance().showGuiScreen(null);
+
+            // Resetting the nbt tags in level.dat
+            NBTTagCompound leveldatNBT;
+
+            leveldatNBT = NBTHelper.readNBTFromFile(new File(worldDir, "level.dat"));
+
+            NBTTagCompound etfuturumNBT = leveldatNBT.getCompoundTag(Reference.MOD_ID + ".container");
+
+            if(WorldHeightHandler.isIncreasedWorldHeightEnabled()) {
+
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), true);
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+
+            } else {
+
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), false);
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), 256);
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_MIGRATED.toString(), false);
+                etfuturumNBT.setInteger(NBTTags.HEIGHT_OFFSET.toString(), 0);
+            }
+
+            NBTHelper.writeNBTToFile(leveldatNBT, new File(worldDir, "level.dat"));
+
+            // Load world again
+            FMLClientHandler.instance().tryLoadExistingWorld(parent, worldDir.getName(), saveName);
+
+        } else if (button.id == 1) {
+
+            ObfuscationReflectionHelper.setPrivateValue(GuiSelectWorld.class, (GuiSelectWorld)parent, false, "field_"+"146634_i");
+            FMLClientHandler.instance().showGuiScreen(parent);
+        }
+
+        super.actionPerformed(button);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightConfirmMigration.java
+++ b/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightConfirmMigration.java
@@ -1,0 +1,131 @@
+package ganymedes01.etfuturum.client.gui;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import ganymedes01.etfuturum.EtFuturum;
+import net.minecraft.client.gui.*;
+import net.minecraft.util.StatCollector;
+
+import java.awt.*;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+
+public class GuiWorldHeightConfirmMigration extends GuiYesNo implements GuiYesNoCallback{
+
+    private int flag;
+    private GuiSelectWorld parent;
+    private String description;
+    private String confirmation;
+    private File worldDir;
+    private String saveName;
+
+    private int linkWidth, linkX, linkY;
+
+    public GuiWorldHeightConfirmMigration(GuiSelectWorld parent, String title, String description, File worldDir, String saveName) {
+
+        super(null, title, description, StatCollector.translateToLocal("gui.worldheight.button.migrate"), StatCollector.translateToLocal("gui.toMenu"), 0);
+
+        this.description = description;
+
+        this.worldDir = worldDir;
+        this.saveName = saveName;
+        this.parent = parent;
+        this.confirmation = StatCollector.translateToLocal("gui.worldheight.migration.confirmation");
+    }
+
+    @Override
+    public void initGui() {
+
+        linkWidth = fontRendererObj.getStringWidth(EtFuturum.githubURL);
+
+        this.buttonList.add(new GuiOptionButton(0, this.width / 2 - 155, this.height / 6 * 5 , this.confirmButtonText));
+        this.buttonList.add(new GuiOptionButton(1, this.width / 2 - 155 + 160, this.height / 6 * 5, this.cancelButtonText));
+    }
+
+    @Override
+    protected void actionPerformed(GuiButton button) {
+
+        if(button.id == 0) {
+
+            this.mc.displayGuiScreen((GuiScreen) null);
+
+            FMLClientHandler.instance().showGuiScreen(new GuiWorldHeightMigrationProgress(parent, worldDir, saveName));
+
+        } else {
+
+            ObfuscationReflectionHelper.setPrivateValue(GuiSelectWorld.class, (GuiSelectWorld)parent, false, "field_"+"146634_i");
+            FMLClientHandler.instance().showGuiScreen(parent);
+        }
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+
+        this.drawDefaultBackground();
+
+        int y = this.height / 6;
+
+        this.drawCenteredString(this.fontRendererObj, this.field_146351_f, this.width / 2, y - 20, 16777215);
+
+        y += 20;
+
+        List<String> lines = fontRendererObj.listFormattedStringToWidth(description, this.width - 50);
+
+        for (String descriptionLine : lines) {
+
+            this.drawCenteredString(this.fontRendererObj, descriptionLine, this.width / 2, y, 16777215);
+
+            y += 17;
+        }
+
+        this.drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.worldheight.migration.github"), this.width / 2, y += 40, 16777215);
+
+        linkX = this.width / 2 - linkWidth / 2;
+        linkY = y += 20;
+
+        if (mouseX >= linkX && mouseX <= linkX + linkWidth && mouseY >= linkY && mouseY <= linkY + 12) {
+
+            this.drawString(this.fontRendererObj, EtFuturum.githubURL, linkX, linkY, 0x55AAFF);
+
+        } else {
+
+            this.drawString(this.fontRendererObj, EtFuturum.githubURL, linkX, linkY, 0xAAFFAA);
+        }
+
+        this.drawCenteredString(this.fontRendererObj, confirmation, this.width / 2, this.height / 6 * 5 - 40, 0xFFAAAA);
+
+        for (GuiButton guiButton : this.buttonList) {
+
+            ((GuiButton) guiButton).drawButton(this.mc, mouseX, mouseY);
+        }
+
+        for (GuiLabel guiLabel : this.labelList) {
+
+            ((GuiLabel) guiLabel).func_146159_a(this.mc, mouseX, mouseY);
+        }
+    }
+
+    @Override
+    protected void mouseClicked(int mouseX, int mouseY, int mouseButton) {
+
+        if (mouseX >= linkX && mouseX <= linkX + linkWidth && mouseY >= linkY && mouseY <= linkY + 12) {
+
+            openLink(EtFuturum.githubURL);
+        }
+
+        super.mouseClicked(mouseX, mouseY, mouseButton);
+    }
+
+    private void openLink(String url) {
+
+        try {
+
+            Desktop.getDesktop().browse(new URI(url));
+
+        } catch (Exception e) {
+
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightMigrationProgress.java
+++ b/src/main/java/ganymedes01/etfuturum/client/gui/GuiWorldHeightMigrationProgress.java
@@ -1,0 +1,172 @@
+package ganymedes01.etfuturum.client.gui;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import ganymedes01.etfuturum.world.WorldHeightHandler.WorldHeightMigrator;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiOptionButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiSelectWorld;
+import net.minecraft.util.StatCollector;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class GuiWorldHeightMigrationProgress extends GuiScreen implements IGUIProgress {
+
+    private final Logger logger = LogManager.getLogger();
+
+    private volatile GuiSelectWorld parent;
+    private volatile int progress = 5;
+    private volatile int maxProgress = 10;
+    private volatile String progressText;
+    private volatile File worldDir;
+    private volatile String saveName;
+
+    //Marks the result of the migration. 0 = not done; 1 = successful; 2 = failed
+    private volatile byte successfulMigration = 0;
+
+    public GuiWorldHeightMigrationProgress(GuiSelectWorld parent, File worldDir, String saveName) {
+
+        this.parent = parent;
+        this.worldDir = worldDir;
+        this.saveName = saveName;
+    }
+
+    @Override
+    public void initGui() {
+
+        this.buttonList.add(new GuiOptionButton(0, (this.width - 150) / 2, this.height / 6 * 5 , "Load World"));
+        this.buttonList.add(new GuiOptionButton(1, (this.width - 150) / 2, this.height / 6 * 5 , "Return to Home"));
+
+        buttonList.get(0).enabled = false;
+        buttonList.get(0).visible = false;
+        buttonList.get(1).enabled = false;
+        buttonList.get(1).visible = false;
+
+        startMigration();
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+
+        this.drawDefaultBackground();
+
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+
+        drawCenteredString(fontRendererObj, StatCollector.translateToLocal("gui.worldheight.migration.inprogress"), centerX, centerY - 50, 0xFFFFFF);
+
+        int progressBarWidth = this.width / 10 * 6;
+        int progressBarHeight = 10;
+
+        int filled = progress >= 0 ? (int)((progress / (float) maxProgress) * progressBarWidth) : maxProgress * progressBarWidth;
+
+        drawRect(centerX - progressBarWidth / 2, centerY - progressBarHeight / 2, centerX + progressBarWidth / 2, centerY + progressBarHeight / 2, 0xFFFFFFFF);
+
+        if(maxProgress > 0) {
+
+            drawRect(centerX - progressBarWidth / 2, centerY - progressBarHeight / 2, centerX - progressBarWidth / 2 + filled, centerY + progressBarHeight / 2, 0xFF55FF55);
+        }
+
+        drawCenteredString(fontRendererObj, progressText + (progress >= 0 ? ": " + progress + " / " + maxProgress : ""), centerX, centerY + 15, 0x55FF55);
+
+        if (successfulMigration == 1) {
+
+            //((GuiButton) this.buttonList.get(0)).drawButton(this.mc, mouseX, mouseY);
+
+        } else if (successfulMigration == 2) {
+
+            List<String> failedTextLines = fontRendererObj.listFormattedStringToWidth(StatCollector.translateToLocal("gui.worldheight.migration.failed.text"), this.width / 10 * 5);
+
+            int y = centerY + 40;
+
+            for (String failedText : failedTextLines) {
+
+                this.drawCenteredString(this.fontRendererObj, failedText, this.width / 2, y += 17, 0xFFFFFF);
+            }
+
+            //((GuiButton) this.buttonList.get(1)).drawButton(this.mc, mouseX, mouseY);
+        }
+
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    protected void actionPerformed(GuiButton button) {
+
+        if (successfulMigration == 1) {
+
+            this.mc.displayGuiScreen((GuiScreen)null);
+
+            // Load world again
+            System.out.println("Welt neu laden!");
+            FMLClientHandler.instance().tryLoadExistingWorld(parent, worldDir.getName(), saveName);
+
+        } else if (successfulMigration == 2) {
+
+            ObfuscationReflectionHelper.setPrivateValue(GuiSelectWorld.class, parent, false, "field_" + "146634_i");
+            FMLClientHandler.instance().showGuiScreen(parent);
+
+        } else {
+
+            logger.info("Migration of world {} is not done yet!", worldDir.getName());
+        }
+    }
+
+    private void startMigration() {
+
+        new Thread(() -> {
+
+            try {
+
+                WorldHeightMigrator.migrateWorldHeightWithProgress(worldDir, this);
+
+            } catch (IOException e) {
+
+                logger.error("World Migration failed! Stopped loading world.", e);
+
+                setSuccessful((byte) 2);
+            }
+        }, "World Height Migration Thread").start();
+    }
+
+    @Override
+    public void setProgress(int progress) {
+
+        this.progress = progress;
+    }
+
+    @Override
+    public void setMaxProgress(int maxProgress) {
+
+        this.maxProgress = maxProgress;
+    }
+
+    @Override
+    public void setProgressText(String progressText) {
+
+        this.progressText = progressText;
+    }
+
+    @Override
+    public void setSuccessful(byte successful) {
+
+        this.successfulMigration = successful;
+        if (!buttonList.isEmpty()) {
+            switch (successful) {
+                case 1:
+                    buttonList.get(0).enabled = true;
+                    buttonList.get(0).visible = true;
+                    break;
+                case 2:
+                    buttonList.get(1).enabled = true;
+                    buttonList.get(1).visible = true;
+                    break;
+            }
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/client/gui/IGUIProgress.java
+++ b/src/main/java/ganymedes01/etfuturum/client/gui/IGUIProgress.java
@@ -1,0 +1,29 @@
+package ganymedes01.etfuturum.client.gui;
+
+public interface IGUIProgress {
+
+    /*
+    Progress lower than 0 disables the progress drawing. So only the progress text is shown.
+    */
+    void setProgress(int progress);
+
+
+    /*
+    If progress is lower than 0 and max progress is 0 no filled progress bar will be rendered.
+    And if progress is lower than 0 and max progress is 1 a fully filled progress bar will be rendered.
+     */
+    void setMaxProgress(int maxProgress);
+
+    /*
+    Set a short description which task is running.
+     */
+    void setProgressText(String progressText);
+
+    /*
+    Set a flag for the result of the migration.
+    0 = not done
+    1 = successful
+    2 = failed
+    */
+    void setSuccessful(byte successful);
+}

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigExperiments.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigExperiments.java
@@ -19,6 +19,9 @@ public class ConfigExperiments extends ConfigBase {
 	public static boolean enableDripstone;
 	public static boolean enableLightningRod;
 	public static boolean enableBubbleColumns;
+	public static boolean enableIncreasedWorldHeight;
+	public static int maxWorldHeight;
+	public static int worldHeightOffset;
 
 	public static boolean netherDimensionProvider;
 	public static boolean endDimensionProvider;
@@ -49,6 +52,9 @@ public class ConfigExperiments extends ConfigBase {
 		enableMossAzalea = getBoolean("enableMossAzalea", catExperiments, false, "Enables moss and azalea. Currently azalea saplings do not grow.");
 		enableLightningRod = getBoolean("enableLightningRod", catExperiments, false, "Completely nonfunctional.");
 		enableBubbleColumns = getBoolean("enableBubbleColumns", catExperiments, false, "Places in the world but currently does nothing.");
+		enableIncreasedWorldHeight = getBoolean("enableIncreasedWorldHeight", catExperiments, false, "Increases the world height. Overrides the server build limit. Changing these settings could break your world! Not tested for mod compat.");
+		maxWorldHeight = getInt("maxWorldHeight", catExperiments, 512, 256, 512, "Defines the maximum world height. Changing these settings could break your world! Requires enable increased world height.");
+		worldHeightOffset = getInt("worldHeightOffset", catExperiments, 64, -128, 128, "New worlds will be generate higher or lower by this offset. And your existing worlds gets shifted up or down on first loading. This can serve various purposes. For example to have more space below to generate big caves. Must be a multiple of 16! Disable with 0. Requires enable increased world height.");
 
 		netherDimensionProvider = getBoolean("netherDimensionProvider", catExperiments, false, "Enables the Nether dimension provider override needed for supplying custom biomes. This is partially ignored if Netherlicious is installed. Netherlicious has compat to generate Et Futurum Requiem biomes with Netherlicious blocks.\nThis is so you can have vanilla-style biomes in Netherlicious while Requiem is installed. Turning this off or setting each individual biome ID to -1 will prevent my version of Nether biomes from generating. Don't forget to turn off my Nether blocks in blocksitems.cfg since my biomes will generate with Netherlicious blocks if available. [not implemented yet]");
 		endDimensionProvider = getBoolean("endDimensionProvider", catExperiments, false, "Enables outer end island generation from 1.9. Gateways are implemented but currently don't generate, but they work. The new dragon fight is currently not implemented and it does not spawn any gateways.");

--- a/src/main/java/ganymedes01/etfuturum/core/utils/helpers/NBTHelper.java
+++ b/src/main/java/ganymedes01/etfuturum/core/utils/helpers/NBTHelper.java
@@ -1,0 +1,46 @@
+package ganymedes01.etfuturum.core.utils.helpers;
+
+import cpw.mods.fml.common.FMLLog;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+public class NBTHelper {
+
+    /*
+    Can be used to read NBT data from level.dat or playerdata files for example.
+     */
+    public static NBTTagCompound readNBTFromFile(File file) {
+
+        NBTTagCompound nbt = null;
+
+        try {
+
+            nbt = CompressedStreamTools.readCompressed(new FileInputStream(file));
+
+        } catch (Exception e) {
+
+            FMLLog.warning("There appears to be a problem writing the NBT to file: %s.", file.getAbsolutePath());
+        }
+
+        return nbt;
+    }
+
+    /*
+    Can be used to write NBT data to level.dat or playerdata files for example.
+     */
+    public static void writeNBTToFile(NBTTagCompound nbt, File file) {
+
+        try {
+
+            CompressedStreamTools.writeCompressed(nbt, new FileOutputStream(file));
+
+        } catch (Exception e) {
+
+            FMLLog.warning("There appears to be a problem writing the NBT to file: %s.", file.getAbsolutePath());
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/ducks/IS22PacketExtended.java
+++ b/src/main/java/ganymedes01/etfuturum/ducks/IS22PacketExtended.java
@@ -1,0 +1,8 @@
+package ganymedes01.etfuturum.ducks;
+
+import net.minecraft.world.chunk.Chunk;
+
+public interface IS22PacketExtended {
+
+    void initExtendedS22Packet(int numberOfTiles, int[] locations, Chunk chunk);
+}

--- a/src/main/java/ganymedes01/etfuturum/lib/Reference.java
+++ b/src/main/java/ganymedes01/etfuturum/lib/Reference.java
@@ -9,6 +9,8 @@ public class Reference {
 	//May be inlined later
 	public static final String MOD_ID = "etfuturum";
 	public static final String MOD_NAME = "Et Futurum Requiem";
+	public static final String MOD_CONTAINER_ID = MOD_ID + ".container";
+	public static final String MOD_CONTAINER_NAME = MOD_NAME + " Container";
 	public static final String VERSION_NUMBER = Tags.VERSION;
 	public static final String MOD_GROUP = "ganymedes01.etfuturum";
 	public static final String MCAssetVer = "minecraft_1.21";

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -5,10 +5,7 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import ganymedes01.etfuturum.Tags;
 import ganymedes01.etfuturum.compat.CompatMisc;
 import ganymedes01.etfuturum.configuration.ConfigBase;
-import ganymedes01.etfuturum.configuration.configs.ConfigEnchantsPotions;
-import ganymedes01.etfuturum.configuration.configs.ConfigEntities;
-import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
-import ganymedes01.etfuturum.configuration.configs.ConfigTweaks;
+import ganymedes01.etfuturum.configuration.configs.*;
 import ganymedes01.etfuturum.lib.Reference;
 import net.minecraft.launchwrapper.Launch;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -286,6 +283,50 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 			mixins.add("foxes.MixinEntityWolf");
 		}
 
+		mixins.add("worldheight.MixinFMLClientHandler");
+		mixins.add("worldheight.MixinAnvilChunkLoader");
+
+		if(ConfigExperiments.enableIncreasedWorldHeight) {
+
+			mixins.add("worldheight.AccessorPlayerManager");
+			mixins.add("worldheight.MixinWorldProvider");
+			mixins.add("worldheight.MixinWorld");
+			mixins.add("worldheight.MixinChunk");
+			mixins.add("worldheight.MixinEntityPlayerMP");
+			mixins.add("worldheight.MixinC07PacketPlayerDigging");
+			mixins.add("worldheight.MixinC08PacketPlayerBlockPlacement");
+			mixins.add("worldheight.MixinS21PacketChunkData");
+			mixins.add("worldheight.MixinS22PacketMultiBlockChange");
+			mixins.add("worldheight.MixinS23PacketBlockChange");
+			mixins.add("worldheight.MixinS26PacketMapChunkBulk");
+			mixins.add("worldheight.MixinItemBlock");
+			mixins.add("worldheight.MixinPlayerInstance");
+			mixins.add("worldheight.MixinChunkCache");
+			mixins.add("worldheight.MixinWorldType");
+
+			mixins.add("worldheight.worldgen.MixinBiomeDecorator");
+			mixins.add("worldheight.worldgen.MixinMapGenCaves");
+			mixins.add("worldheight.worldgen.MixinWorldGenCanopyTree");
+			mixins.add("worldheight.worldgen.MixinWorldGenDoublePlant");
+			mixins.add("worldheight.worldgen.MixinWorldGenFlowers");
+			mixins.add("worldheight.worldgen.MixinWorldGenForest");
+			mixins.add("worldheight.worldgen.MixinWorldGenHugeTrees");
+			mixins.add("worldheight.worldgen.MixinWorldGenSavannaTree");
+			mixins.add("worldheight.worldgen.MixinWorldGenSpikes");
+			mixins.add("worldheight.worldgen.MixinWorldGenSwamp");
+			mixins.add("worldheight.worldgen.MixinWorldGenTrees");
+			mixins.add("worldheight.worldgen.MixinWorldGenTaiga1");
+			mixins.add("worldheight.worldgen.MixinWorldGenTaiga2");
+
+			if(side == MixinEnvironment.Side.CLIENT) {
+
+				mixins.add("worldheight.client.MixinChunkCacheClient");
+				mixins.add("worldheight.client.MixinNetHandlerPlayClient");
+				mixins.add("worldheight.client.MixinRenderGlobal");
+				mixins.add("worldheight.client.MixinWorldClient");
+			}
+		}
+
 		return mixins;
 	}
 
@@ -296,7 +337,8 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 
 	@Override
 	public String getModContainerClass() {
-		return null;
+
+		return "ganymedes01.etfuturum.EtFuturumContainer";
 	}
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/AccessorPlayerManager.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/AccessorPlayerManager.java
@@ -1,0 +1,14 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import net.minecraft.server.management.PlayerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(PlayerManager.class)
+public interface AccessorPlayerManager {
+
+    @Accessor("chunkWatcherWithPlayers")
+    List getChunkWatcherWithPlayers();
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinAnvilChunkLoader.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinAnvilChunkLoader.java
@@ -1,0 +1,76 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.NibbleArray;
+import net.minecraft.world.chunk.storage.AnvilChunkLoader;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AnvilChunkLoader.class)
+public class MixinAnvilChunkLoader {
+
+    @ModifyConstant(method = "readChunkFromNBT", constant = @Constant(intValue = 16))
+    private int getIncreasedChunkSections(int original, World world, NBTTagCompound nbt) {
+
+        return WorldHeightHandler.getChunkSections();
+    }
+
+    @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagList;tagCount()I"), cancellable = true)
+    private void continueIfAboveWorldHeight(World world, NBTTagCompound chunkNbt, CallbackInfoReturnable<Chunk> cir, @Local(name = "chunk") Chunk chunk, @Local(name = "nbttaglist") NBTTagList nbttaglist, @Local(name = "b0") byte b0, @Local(name = "aextendedblockstorage") ExtendedBlockStorage[] aextendedblockstorage, @Local(name = "flag") boolean flag) {
+
+        for (int k = 0; k < nbttaglist.tagCount(); ++k) {
+
+            NBTTagCompound sectionTag = nbttaglist.getCompoundTagAt(k);
+
+            byte y = sectionTag.getByte("Y");
+
+            if (y >= WorldHeightHandler.getChunkSections()) { continue; }
+
+            ExtendedBlockStorage storage = new ExtendedBlockStorage(y << 4, flag);
+            storage.setBlockLSBArray(sectionTag.getByteArray("Blocks"));
+
+            if (sectionTag.hasKey("Data", 7)) {
+
+                storage.setBlockMetadataArray(new NibbleArray(sectionTag.getByteArray("Data"), 4));
+            }
+
+            storage.setBlocklightArray(new NibbleArray(sectionTag.getByteArray("BlockLight"), 4));
+
+            if (flag) {
+
+                storage.setSkylightArray(new NibbleArray(sectionTag.getByteArray("SkyLight"), 4));
+            }
+
+            storage.removeInvalidBlocks();
+            aextendedblockstorage[y] = storage;
+        }
+
+        chunk.setStorageArrays(aextendedblockstorage);
+
+        if (chunkNbt.hasKey("Biomes", 7)) {
+
+            chunk.setBiomeArray(chunkNbt.getByteArray("Biomes"));
+        }
+
+        cir.setReturnValue(chunk);
+    }
+
+    @Redirect(method = "loadEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntity;createAndLoadEntity(Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/tileentity/TileEntity;"))
+    private TileEntity ignoreTileEntitiesAboveWorldHeight(NBTTagCompound tileEntities) {
+
+        if(tileEntities.getInteger("y") > WorldHeightHandler.getMaxWorldHeight()) {
+
+            return null;
+        }
+
+        return TileEntity.createAndLoadEntity(tileEntities);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinC07PacketPlayerDigging.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinC07PacketPlayerDigging.java
@@ -1,0 +1,24 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.client.C07PacketPlayerDigging;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(C07PacketPlayerDigging.class)
+public class MixinC07PacketPlayerDigging {
+
+    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 1))
+    private short readPacketDataForExtendedHeight(PacketBuffer data) {
+
+        return data.readShort();
+    }
+
+    @Redirect(method = "writePacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;", ordinal = 1))
+    private ByteBuf writePacketDataForExtendedHeight(PacketBuffer data, int value) {
+
+        return data.writeShort(value);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinC08PacketPlayerBlockPlacement.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinC08PacketPlayerBlockPlacement.java
@@ -1,0 +1,24 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(C08PacketPlayerBlockPlacement.class)
+public class MixinC08PacketPlayerBlockPlacement {
+
+    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 0))
+    private short readPacketDataForExtendedHeight(PacketBuffer data) {
+
+        return data.readShort();
+    }
+
+    @Redirect(method = "writePacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;", ordinal = 0))
+    private ByteBuf writePacketDataForExtendedHeight(PacketBuffer data, int value) {
+
+        return data.writeShort(value);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinChunk.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinChunk.java
@@ -1,0 +1,34 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(Chunk.class)
+public abstract class MixinChunk {
+
+    @Shadow public World worldObj;
+
+    @ModifyConstant(method = "<init>", constant = @Constant(intValue = 16))
+    private int getIncreasedChunkSections(int original) {
+
+        return WorldHeightHandler.getChunkSections();
+    }
+
+    @ModifyConstant(method = "getAreLevelsEmpty", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return worldObj.provider.getHeight();
+    }
+
+    @ModifyConstant(method = { "getAreLevelsEmpty",
+                               "relightBlock" }, constant = @Constant(intValue = 255))
+    private int getIncreasedWorldHeightMinusOne(int original) {
+
+        return worldObj.provider.getHeight() - 1;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinChunkCache.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinChunkCache.java
@@ -1,0 +1,22 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ChunkCache.class)
+public class MixinChunkCache {
+
+    @Shadow private World worldObj;
+
+    @ModifyConstant(method = { "getBlock",
+                               "getBlockMetadata",
+                               "getHeight"}, constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return worldObj.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinEntityPlayerMP.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinEntityPlayerMP.java
@@ -1,0 +1,17 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(EntityPlayerMP.class)
+public class MixinEntityPlayerMP {
+
+    @ModifyConstant(method = "onUpdate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return ((Entity)(Object)this).worldObj.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinFMLClientHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinFMLClientHandler.java
@@ -1,0 +1,69 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import cpw.mods.fml.client.FMLClientHandler;
+import ganymedes01.etfuturum.Tags;
+import ganymedes01.etfuturum.client.gui.GuiWorldHeightConfirmDisabling;
+import ganymedes01.etfuturum.client.gui.GuiWorldHeightConfirmMigration;
+import ganymedes01.etfuturum.core.utils.helpers.NBTHelper;
+import ganymedes01.etfuturum.lib.Reference;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import ganymedes01.etfuturum.world.WorldHeightHandler.NBTTags;
+import ganymedes01.etfuturum.world.WorldHeightHandler.WorldHeightMigrator;
+import net.minecraft.client.gui.GuiSelectWorld;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.File;
+import java.io.IOException;
+
+@Mixin(FMLClientHandler.class)
+public abstract class MixinFMLClientHandler {
+
+    @Shadow(remap = false) public abstract void showGuiScreen(Object clientGuiElement);
+
+    @Inject(method = "tryLoadExistingWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getCompoundTag(Ljava/lang/String;)Lnet/minecraft/nbt/NBTTagCompound;"), cancellable = true)
+    private void checkIncreasedHeight(GuiSelectWorld gui, String dirName, String saveName, CallbackInfo ci, @Local File dir, @Local NBTTagCompound leveldatNBT) throws IOException {
+
+        NBTTagCompound etfuturumNBT = leveldatNBT.getCompoundTag(Reference.MOD_CONTAINER_ID);
+
+        int migrationFlag = WorldHeightMigrator.isMigrationNeeded(etfuturumNBT);
+
+        switch (migrationFlag) {
+            case 1:
+                showGuiScreen(new GuiWorldHeightConfirmMigration(gui, StatCollector.translateToLocal("gui.worldheight.migration.title"),
+                        StatCollector.translateToLocalFormatted("gui.worldheight.migration.confirm.description.upper", EnumChatFormatting.LIGHT_PURPLE + Reference.MOD_NAME + EnumChatFormatting.RESET, EnumChatFormatting.GREEN + String.valueOf(WorldHeightHandler.getWorldHeightOffset()) + EnumChatFormatting.RESET),
+                        dir, saveName));
+                ci.cancel();
+                break;
+            case 2:
+                showGuiScreen(new GuiWorldHeightConfirmMigration(gui, StatCollector.translateToLocal("gui.worldheight.migration.title"),
+                        StatCollector.translateToLocalFormatted("gui.worldheight.migration.confirm.description.lower", EnumChatFormatting.LIGHT_PURPLE + Reference.MOD_NAME + EnumChatFormatting.RESET, EnumChatFormatting.GREEN + String.valueOf(WorldHeightHandler.getWorldHeightOffset()) + EnumChatFormatting.RESET, EnumChatFormatting.RED + String.valueOf(Math.abs(WorldHeightHandler.getWorldHeightOffset())) + EnumChatFormatting.RESET),
+                        dir, saveName));
+                ci.cancel();
+                break;
+            case 3:
+                showGuiScreen(new GuiWorldHeightConfirmDisabling(gui, StatCollector.translateToLocal("gui.worldheight.migration.title"),
+                        StatCollector.translateToLocalFormatted("gui.worldheight.migration.description.smaller", EnumChatFormatting.LIGHT_PURPLE + Reference.MOD_NAME + EnumChatFormatting.RESET, EnumChatFormatting.GREEN + String.valueOf(WorldHeightHandler.getMaxWorldHeight()) + EnumChatFormatting.RESET, EnumChatFormatting.RED + String.valueOf(etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString())) + EnumChatFormatting.RESET, EnumChatFormatting.GREEN + String.valueOf(WorldHeightHandler.getMaxWorldHeight()) + EnumChatFormatting.RESET),
+                        dir, saveName));
+                break;
+            case 4:
+                showGuiScreen(new GuiWorldHeightConfirmDisabling(gui, StatCollector.translateToLocal("gui.worldheight.migration.title"),
+                        StatCollector.translateToLocalFormatted("gui.worldheight.migration.confirm.description.disabling", EnumChatFormatting.RED + String.valueOf(etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString())) + EnumChatFormatting.RESET, EnumChatFormatting.RED + String.valueOf(etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString())) + EnumChatFormatting.RESET),
+                        dir, saveName));
+                ci.cancel();
+                break;
+            default:
+                etfuturumNBT.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), WorldHeightHandler.isIncreasedWorldHeightEnabled());
+                etfuturumNBT.setInteger(NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+                NBTHelper.writeNBTToFile(leveldatNBT, new File(dir, "level.dat"));
+                break;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinItemBlock.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinItemBlock.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ItemBlock.class)
+public class MixinItemBlock {
+
+    @ModifyConstant(method = "onItemUse", constant = @Constant(intValue = 255))
+    private int getIncreasedWorldHeightMinusOne(int original, ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
+
+        return world.provider.getHeight() - 1;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinPlayerInstance.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinPlayerInstance.java
@@ -1,0 +1,147 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.ducks.IS22PacketExtended;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S21PacketChunkData;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import net.minecraft.network.play.server.S23PacketBlockChange;
+import net.minecraft.server.management.PlayerManager;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkCoordIntPair;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.ForgeModContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.Arrays;
+
+@Mixin(targets = "net.minecraft.server.management.PlayerManager$PlayerInstance")
+public abstract class MixinPlayerInstance {
+
+    @Shadow private int numberOfTilesToUpdate;
+    @Shadow private ChunkCoordIntPair chunkLocation;
+    @Shadow private int flagsYAreasToUpdate;
+
+    @Shadow public abstract void sendToAllPlayersWatchingChunk(Packet packet);
+    @Shadow public abstract void sendTileToAllPlayersWatchingChunk(TileEntity tileEntity);
+
+    @Shadow(remap = false) PlayerManager this$0;
+
+    @Unique private int[] locationsOfBlockChangeForExtendedHeight = new int[64];
+
+    /**
+     * @author timb8g
+     * @reason Change locationOfBlockChange to int[]
+     */
+    @Overwrite
+    public void flagChunkForUpdate(int x, int y, int z) {
+
+        if (this.numberOfTilesToUpdate == 0) {
+
+            ((AccessorPlayerManager)this.this$0).getChunkWatcherWithPlayers().add(this);
+        }
+
+        this.flagsYAreasToUpdate |= 1 << (y >> 4);
+
+        //if (this.numberOfTilesToUpdate < 64) //Forge; Cache everything, so always run
+        {
+            int locationOfBlock = (x << 16 | z << 12 | y);
+
+            for (int l = 0; l < this.numberOfTilesToUpdate; ++l) {
+
+                if (this.locationsOfBlockChangeForExtendedHeight[l] == locationOfBlock) {
+
+                    return;
+                }
+            }
+
+            if (this.numberOfTilesToUpdate == locationsOfBlockChangeForExtendedHeight.length) {
+
+                locationsOfBlockChangeForExtendedHeight = Arrays.copyOf(locationsOfBlockChangeForExtendedHeight, locationsOfBlockChangeForExtendedHeight.length << 1);
+            }
+
+            this.locationsOfBlockChangeForExtendedHeight[this.numberOfTilesToUpdate++] = locationOfBlock;
+        }
+    }
+
+    /**
+     * @author timb8g
+     * @reason Change locationOfBlockChange to int[] and adjust max world height
+     */
+    @Overwrite
+    public void sendChunkUpdate() {
+
+        if (this.numberOfTilesToUpdate != 0) {
+
+            int i;
+            int j;
+            int k;
+
+            if (this.numberOfTilesToUpdate == 1) {
+
+                i = this.chunkLocation.chunkXPos * 16 + (this.locationsOfBlockChangeForExtendedHeight[0] >> 16 & 15);
+                j = this.locationsOfBlockChangeForExtendedHeight[0] & (this.this$0.getWorldServer().getHeight() - 1);
+                k = this.chunkLocation.chunkZPos * 16 + (this.locationsOfBlockChangeForExtendedHeight[0] >> 12 & 15);
+                this.sendToAllPlayersWatchingChunk(new S23PacketBlockChange(i, j, k, this.this$0.getWorldServer()));
+
+                if (this.this$0.getWorldServer().getBlock(i, j, k).hasTileEntity(this.this$0.getWorldServer().getBlockMetadata(i, j, k))) {
+
+                    this.sendTileToAllPlayersWatchingChunk(this.this$0.getWorldServer().getTileEntity(i, j, k));
+                }
+            } else {
+
+                int l;
+
+                if (this.numberOfTilesToUpdate >= ForgeModContainer.clumpingThreshold) {
+
+                    i = this.chunkLocation.chunkXPos * 16;
+                    j = this.chunkLocation.chunkZPos * 16;
+
+                    this.sendToAllPlayersWatchingChunk(new S21PacketChunkData(this.this$0.getWorldServer().getChunkFromChunkCoords(this.chunkLocation.chunkXPos, this.chunkLocation.chunkZPos), false, this.flagsYAreasToUpdate));
+
+                    // Forge: Grabs ALL tile entities is costly on a modded server, only send needed ones
+                    /*for (k = 0; false && k < 16; ++k) {
+
+                        if ((this.flagsYAreasToUpdate & 1 << k) != 0) {
+
+                            l = k << 4;
+                            List list = this.this$0.getWorldServer().func_147486_a(i, l, j, i + 16, l + 16, j + 16);
+
+                            for (int i1 = 0; i1 < list.size(); ++i1) {
+
+                                this.sendTileToAllPlayersWatchingChunk((TileEntity)list.get(i1));
+                            }
+                        }
+                    }*/
+                } else {
+
+                    S22PacketMultiBlockChange packet = new S22PacketMultiBlockChange();
+                    ((IS22PacketExtended)packet).initExtendedS22Packet(this.numberOfTilesToUpdate, this.locationsOfBlockChangeForExtendedHeight, this.this$0.getWorldServer().getChunkFromChunkCoords(this.chunkLocation.chunkXPos, this.chunkLocation.chunkZPos));
+
+                    this.sendToAllPlayersWatchingChunk(packet);
+                }
+
+                { //Forge: Send only the tile entities that are updated, Adding this brace lets us keep the indent and the patch small
+                    WorldServer world = this.this$0.getWorldServer();
+
+                    for (i = 0; i < this.numberOfTilesToUpdate; ++i) {
+
+                        j = this.chunkLocation.chunkXPos * 16 + (this.locationsOfBlockChangeForExtendedHeight[i] >> 16 & 15);
+                        k = this.locationsOfBlockChangeForExtendedHeight[i] & (this.this$0.getWorldServer().getHeight() - 1);
+                        l = this.chunkLocation.chunkZPos * 16 + (this.locationsOfBlockChangeForExtendedHeight[i] >> 12 & 15);
+
+                        if (world.getBlock(j, k, l).hasTileEntity(world.getBlockMetadata(j, k, l))) {
+
+                            this.sendTileToAllPlayersWatchingChunk(this.this$0.getWorldServer().getTileEntity(j, k, l));
+                        }
+                    }
+                }
+            }
+
+            this.numberOfTilesToUpdate = 0;
+            this.flagsYAreasToUpdate = 0;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS21PacketChunkData.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS21PacketChunkData.java
@@ -1,0 +1,132 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S21PacketChunkData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+@Mixin(S21PacketChunkData.class)
+public abstract class MixinS21PacketChunkData {
+
+    @Shadow private int field_149284_a;     // x position of chunk
+    @Shadow private int field_149282_b;     // z position of chunk
+    @Shadow private int field_149283_c;     // section mask
+    @Shadow private int field_149280_d;     // additional mask
+    @Shadow private byte[] field_149281_e;  // uncompressed write chunk data
+    @Shadow private byte[] field_149278_f;  // uncompressed read chunk data
+    @Shadow private boolean field_149279_g; // include biome data
+    @Shadow private int field_149285_h;     // chunk data bytes
+    @Shadow
+    @Mutable
+    private static byte[] field_149286_i; // compressed chunk data
+    static {
+        field_149286_i = new byte[(ConfigExperiments.maxWorldHeight >> 4) * 12288 + 256]; // (BlockIDs (4096 Bytes) + Metadata (2048 Bytes) + Blocklight (2048 Bytes) + Skylight (2048 Bytes) + MSB-IDs (2048 Bytes)) per Section (20) + Biome-Data (256 Bytes)
+    }
+    @Shadow(remap = false) Semaphore deflateGate;
+
+    @Shadow(remap = false) public abstract void deflate();
+
+    @Inject(method = "func_149275_c", at = @At("HEAD"), cancellable = true)
+    private static void getMaxPacketSizeForExtendedHeight(CallbackInfoReturnable<Integer> cir) {
+
+        cir.setReturnValue(WorldHeightHandler.getChunkSections() * 12288 + 256);  // (BlockIDs (4096 Bytes) + Metadata (2048 Bytes) + Blocklight (2048 Bytes) + Skylight (2048 Bytes) + MSB-IDs (2048 Bytes)) per Section (20) + Biome-Data (256 Bytes)
+    }
+
+    /**
+     * @author timb8g
+     * @reason extend world height
+     */
+    @Overwrite
+    public void readPacketData(PacketBuffer data) throws IOException {
+
+        this.field_149284_a = data.readInt();       // x position of chunk
+        this.field_149282_b = data.readInt();       // z position of chunk
+        this.field_149279_g = data.readBoolean();   // include biome data
+        this.field_149283_c = data.readInt();       // section mask
+        this.field_149280_d = data.readInt();       // additional mask
+        this.field_149285_h = data.readInt();       // chunk data length
+
+        if (field_149286_i.length < this.field_149285_h) {
+
+            field_149286_i = new byte[this.field_149285_h];
+        }
+
+        data.readBytes(field_149286_i, 0, this.field_149285_h);
+
+        int sections = 0;
+        int msbsections = 0; //BugFix: MC does not read the MSB array from the packet properly, causing issues for servers that use blocks > 256
+        int j;
+
+        for (j = 0; j < WorldHeightHandler.getChunkSections(); ++j) {
+
+            sections += this.field_149283_c >> j & 1;
+            msbsections += this.field_149280_d >> j & 1;
+        }
+
+        j = 10240 * sections;       // in 12288 the msb bytes already included
+        j += 2048 * msbsections;
+
+        if (this.field_149279_g) {
+
+            j += 256;
+        }
+
+        this.field_149278_f = new byte[j];
+
+        Inflater inflater = new Inflater();
+        inflater.setInput(field_149286_i, 0, this.field_149285_h);
+
+        try {
+
+            inflater.inflate(this.field_149278_f);
+
+        } catch (DataFormatException dataformatexception) {
+
+            throw new IOException("Bad compressed data format");
+
+        } finally {
+
+            inflater.end();
+        }
+    }
+
+    /**
+     * @author timb8g
+     * @reason extended world height
+     */
+    @Overwrite
+    public void writePacketData(PacketBuffer data) throws IOException {
+
+        if (this.field_149281_e == null) {
+
+            deflateGate.acquireUninterruptibly();
+
+            if (this.field_149281_e == null) {
+
+                deflate();
+            }
+
+            deflateGate.release();
+        }
+        System.out.println("Write Section: " + this.field_149283_c);
+        data.writeInt(this.field_149284_a);
+        data.writeInt(this.field_149282_b);
+        data.writeBoolean(this.field_149279_g);
+        data.writeInt(this.field_149283_c);
+        data.writeInt(this.field_149280_d);
+        data.writeInt(this.field_149285_h);
+        data.writeBytes(this.field_149281_e, 0, this.field_149285_h);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS22PacketMultiBlockChange.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS22PacketMultiBlockChange.java
@@ -1,0 +1,62 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.ducks.IS22PacketExtended;
+import net.minecraft.block.Block;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import net.minecraft.world.ChunkCoordIntPair;
+import net.minecraft.world.chunk.Chunk;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+@Mixin(S22PacketMultiBlockChange.class)
+public abstract class MixinS22PacketMultiBlockChange implements IS22PacketExtended {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    @Shadow private ChunkCoordIntPair field_148925_b;
+    @Shadow private int field_148924_d;
+    @Shadow private byte[] field_148926_c;
+
+    @Override
+    public void initExtendedS22Packet(int numberOfTiles, int[] locations, Chunk chunk) {
+
+        this.field_148925_b = new ChunkCoordIntPair(chunk.xPosition, chunk.zPosition);
+        this.field_148924_d = numberOfTiles;
+
+        int j = 6 * numberOfTiles;  // now packet of 6 size because we need two bytes more for positioning
+
+            try {
+
+            ByteArrayOutputStream bytearrayoutputstream = new ByteArrayOutputStream(j);
+            DataOutputStream dataoutputstream = new DataOutputStream(bytearrayoutputstream);
+
+            for (int k = 0; k < numberOfTiles; ++k) {
+
+                int locationX = locations[k] >> 16 & 15;
+                int locationZ = locations[k] >> 12 & 15;
+                int locationY = locations[k] & (chunk.worldObj.getHeight() - 1);
+
+                dataoutputstream.writeInt(locations[k]);
+                dataoutputstream.writeShort((short)((Block.getIdFromBlock(chunk.getBlock(locationX, locationY, locationZ)) & 4095) << 4 | chunk.getBlockMetadata(locationX, locationY, locationZ) & 15));
+            }
+
+            this.field_148926_c = bytearrayoutputstream.toByteArray();
+
+            if (this.field_148926_c.length != j) {
+
+                throw new RuntimeException("Expected length " + j + " doesn\'t match received length " + this.field_148926_c.length);
+            }
+        } catch (IOException ioexception) {
+
+            logger.error("Couldn\'t create bulk block update packet", ioexception);
+
+            this.field_148926_c = null;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS23PacketBlockChange.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS23PacketBlockChange.java
@@ -1,0 +1,24 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S23PacketBlockChange;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(S23PacketBlockChange.class)
+public class MixinS23PacketBlockChange {
+
+    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 0))
+    private short readPacketDataForExtendedHeight(PacketBuffer data) {
+
+        return data.readShort();
+    }
+
+    @Redirect(method = "writePacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;", ordinal = 0))
+    private ByteBuf writePacketDataForExtendedHeight(PacketBuffer data, int value) {
+
+        return data.writeShort(value);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS26PacketMapChunkBulk.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinS26PacketMapChunkBulk.java
@@ -1,0 +1,150 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S21PacketChunkData;
+import net.minecraft.network.play.server.S26PacketMapChunkBulk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+@Mixin(S26PacketMapChunkBulk.class)
+public abstract class MixinS26PacketMapChunkBulk {
+
+    @Shadow private int[] field_149266_a;           // x position of chunks
+    @Shadow private int[] field_149264_b;           // z position of chunks
+    @Shadow private int[] field_149265_c;           // sections masks
+    @Shadow private int[] field_149262_d;           // additional masks
+    @Shadow private byte[] field_149263_e;          // uncompressed write chunk data for all chunks
+    @Shadow private byte[][] field_149260_f;        // uncompressed read chunk data per chunk
+    @Shadow private int field_149261_g;             // compressed chunk data bytes for all chunks
+    @Shadow private boolean field_149267_h;         // world has sky
+    @Shadow private static byte[] field_149268_i;   // compressed chunk data for all chunks
+    @Shadow(remap = false) private Semaphore deflateGate;
+
+    @Shadow(remap = false) public abstract void deflate();
+
+    @ModifyArg(method = "<init>(Ljava/util/List;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/server/S21PacketChunkData;func_149269_a(Lnet/minecraft/world/chunk/Chunk;ZI)Lnet/minecraft/network/play/server/S21PacketChunkData$Extracted;"), index = 2)
+    private int extendedSectionMaskForS21Packet(int original) {
+
+        int sections = WorldHeightHandler.getChunkSections();
+
+        if(sections >= 32) return -1;
+
+        return (1 << sections) - 1;
+    }
+
+    /**
+     * @author timb8g
+     * @reason extended world height
+     */
+    @Overwrite
+    public void readPacketData(PacketBuffer data) throws IOException {
+
+        short chunkCount = data.readShort();
+
+        this.field_149261_g = data.readInt();           // compressed chunk data bytes for all chunks
+        this.field_149267_h = data.readBoolean();       // world has sky
+        this.field_149266_a = new int[chunkCount];      // x position of chunks
+        this.field_149264_b = new int[chunkCount];      // z position of chunks
+        this.field_149265_c = new int[chunkCount];      // sections masks
+        this.field_149262_d = new int[chunkCount];      // additional masks
+        this.field_149260_f = new byte[chunkCount][];   // chunk data per chunk
+
+        if (field_149268_i.length < this.field_149261_g) {
+
+            field_149268_i = new byte[this.field_149261_g];
+        }
+
+        data.readBytes(field_149268_i, 0, this.field_149261_g);
+
+        byte[] abyte = new byte[S21PacketChunkData.func_149275_c() * chunkCount];
+
+        Inflater inflater = new Inflater();
+        inflater.setInput(field_149268_i, 0, this.field_149261_g);
+
+        try {
+
+            inflater.inflate(abyte);
+
+        } catch (DataFormatException dataformatexception) {
+
+            throw new IOException("Bad compressed data format");
+
+        } finally {
+
+            inflater.end();
+        }
+
+        int i = 0;
+
+        for (int j = 0; j < chunkCount; ++j) {
+
+            this.field_149266_a[j] = data.readInt();
+            this.field_149264_b[j] = data.readInt();
+            this.field_149265_c[j] = data.readInt();
+            this.field_149262_d[j] = data.readInt();
+            int k = 0;
+            int l = 0;
+            int i1;
+
+            for (i1 = 0; i1 < WorldHeightHandler.getChunkSections(); ++i1) {
+
+                k += this.field_149265_c[j] >> i1 & 1;
+                l += this.field_149262_d[j] >> i1 & 1;
+            }
+
+            i1 = 2048 * 4 * k + 256;
+            i1 += 2048 * l;
+
+            if (this.field_149267_h) {
+
+                i1 += 2048 * k;
+            }
+
+            this.field_149260_f[j] = new byte[i1];
+            System.arraycopy(abyte, i, this.field_149260_f[j], 0, i1);
+            i += i1;
+        }
+    }
+
+    /**
+     * @author timb8g
+     * @reason extended world height
+     */
+    @Overwrite
+    public void writePacketData(PacketBuffer data) throws IOException {
+
+        if (this.field_149263_e == null) {
+
+            deflateGate.acquireUninterruptibly();
+
+            if (this.field_149263_e == null) {
+
+                deflate();
+            }
+
+            deflateGate.release();
+        }
+
+        data.writeShort(this.field_149266_a.length);
+        data.writeInt(this.field_149261_g);
+        data.writeBoolean(this.field_149267_h);
+        data.writeBytes(this.field_149263_e, 0, this.field_149261_g);
+
+        for (int i = 0; i < this.field_149266_a.length; ++i) {
+
+            data.writeInt(this.field_149266_a[i]);
+            data.writeInt(this.field_149264_b[i]);
+            data.writeInt(this.field_149265_c[i]);
+            data.writeInt(this.field_149262_d[i]);
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorld.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorld.java
@@ -1,0 +1,47 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(World.class)
+public abstract class MixinWorld {
+
+    @Shadow public WorldProvider provider;
+
+    @ModifyConstant(method = { "setBlock",
+                               "setBlockMetadataWithNotify",
+                               "getBlock",
+                               "getBlockMetadata",
+                               "getTileEntity",
+                               "checkChunksExist",
+                               "blockExists",
+                               "setLightValue",
+                               "getSkyBlockTypeBrightness",
+                               "getSavedLightValue",
+                               "getFullBlockLightValue",
+                               "getBlockLightValue_do"}, constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return this.provider.getHeight();
+    }
+
+    @ModifyConstant(method = { "getBlockLightOpacity",
+                               "canBlockFreezeBody",
+                               "canSnowAtBody" }, constant = @Constant(intValue = 256), remap = false)
+    private int getIncreasedWorldHeightNoRemap(int original) {
+
+        return this.provider.getHeight();
+    }
+
+    @ModifyConstant(method = { "getSavedLightValue",
+                               "getFullBlockLightValue",
+                               "getBlockLightValue_do" }, constant = @Constant(intValue = 255))
+    private int getIncreasedWorldHeightMinusOne(int original) {
+
+        return this.provider.getHeight() - 1;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorldProvider.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorldProvider.java
@@ -1,0 +1,29 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.world.WorldProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(WorldProvider.class)
+public class MixinWorldProvider {
+
+    @Shadow public boolean hasNoSky;
+
+    @Inject(method = "getHeight", at = @At("HEAD"), cancellable = true, remap = false)
+    private void getIncreasedHeight(CallbackInfoReturnable<Integer> cir) {
+
+        cir.setReturnValue(WorldHeightHandler.getMaxWorldHeight());
+    }
+
+    @ModifyConstant(method = "getActualHeight", constant = @Constant(intValue = 256), remap = false)
+    private int getIncreasedActualHeight(int original) {
+
+        return WorldHeightHandler.getMaxWorldHeight() > 128 && hasNoSky ? 128 : WorldHeightHandler.getMaxWorldHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorldType.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/MixinWorldType.java
@@ -1,0 +1,32 @@
+package ganymedes01.etfuturum.mixins.early.worldheight;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import ganymedes01.etfuturum.world.generate.ChunkProviderIncreasedHeight;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderFlat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static net.minecraft.world.WorldType.FLAT;
+
+@Mixin(WorldType.class)
+public class MixinWorldType {
+
+    @ModifyConstant(method = "getCloudHeight", constant = @Constant(floatValue = 128.0F), remap = false)
+    private float getIncreasedCloudHeight(float original) {
+
+        return WorldHeightHandler.getWorldHeightOffset() != 0 ? original + WorldHeightHandler.getWorldHeightOffset() : original;
+    }
+
+    @Inject(method = "getChunkGenerator", at = @At("RETURN"), cancellable = true, remap = false)
+    private void getIncreasedHeightChunkGenerator(World world, String generatorOptions, CallbackInfoReturnable<IChunkProvider> cir) {
+
+        cir.setReturnValue(((WorldType)(Object)this) == FLAT ? new ChunkProviderFlat(world, world.getSeed(), world.getWorldInfo().isMapFeaturesEnabled(), generatorOptions) : new ChunkProviderIncreasedHeight(world, world.getSeed(), world.getWorldInfo().isMapFeaturesEnabled()));
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinChunkCacheClient.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinChunkCacheClient.java
@@ -1,0 +1,28 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.client;
+
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ChunkCache.class)
+public class MixinChunkCacheClient {
+
+    @Shadow private World worldObj;
+
+    @ModifyConstant(method = { "getSkyBlockTypeBrightness",
+                               "getSpecialBlockBrightness" }, constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return worldObj.provider.getHeight();
+    }
+
+    @ModifyConstant(method = { "getSkyBlockTypeBrightness",
+                               "getSpecialBlockBrightness" }, constant = @Constant(intValue = 255))
+    private int getIncreasedWorldHeightMinusOne(int original) {
+
+        return worldObj.provider.getHeight() - 1;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinNetHandlerPlayClient.java
@@ -1,0 +1,70 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.client;
+
+import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
+import net.minecraft.block.Block;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+@Mixin(NetHandlerPlayClient.class)
+public class MixinNetHandlerPlayClient {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    @Shadow(aliases = "field_147300_g", remap = false) private WorldClient clientWorldController;
+
+    @ModifyConstant(method = { "handleChunkData",
+                               "handleMapChunkBulk" } , constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return clientWorldController.getHeight();
+    }
+
+    /**
+     * @author timb8g
+     * @reason change locationOfBlocks processing to int
+     */
+    @Overwrite
+    public void handleMultiBlockChange(S22PacketMultiBlockChange packetIn) {
+
+        int i = packetIn.func_148920_c().chunkXPos * 16;
+        int j = packetIn.func_148920_c().chunkZPos * 16;
+
+        if (packetIn.func_148921_d() != null) {
+
+            DataInputStream datainputstream = new DataInputStream(new ByteArrayInputStream(packetIn.func_148921_d()));
+
+            try {
+
+                for (int k = 0; k < packetIn.func_148922_e(); ++k) {
+
+                    int locationOfBlock = datainputstream.readInt();
+                    short blockData = datainputstream.readShort();
+
+                    int blockID = blockData >> 4 & 4095;
+                    int blockMeta = blockData & 15;
+
+                    int locationX = locationOfBlock >> 16 & 15;
+                    int locationZ = locationOfBlock >> 12 & 15;
+                    int locationY = locationOfBlock & (ConfigExperiments.maxWorldHeight - 1);
+
+                    this.clientWorldController.func_147492_c(locationX + i, locationY, locationZ + j, Block.getBlockById(blockID), blockMeta);
+                }
+            } catch (IOException ioexception) {
+
+                logger.error("Couldn\'t handle bulk block update packet", ioexception);
+            }
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinRenderGlobal.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinRenderGlobal.java
@@ -1,0 +1,27 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.client;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderGlobal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(RenderGlobal.class)
+public class MixinRenderGlobal {
+
+    @Shadow private Minecraft mc;
+
+    @ModifyConstant(method = "<init>" , constant = @Constant(intValue = 16, ordinal = 0))
+    private int getIncreasedChunkSectionsConstructor(int original, Minecraft minecraft) {
+
+        return WorldHeightHandler.getChunkSections();
+    }
+
+    @ModifyConstant(method = "loadRenderers" , constant = @Constant(intValue = 16, ordinal = 0))
+    private int getIncreasedChunkSections(int original) {
+
+        return WorldHeightHandler.getChunkSections();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinWorldClient.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/client/MixinWorldClient.java
@@ -1,0 +1,17 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.client;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.client.multiplayer.WorldClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(WorldClient.class)
+public class MixinWorldClient {
+
+    @ModifyConstant(method = "doPreChunk", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original) {
+
+        return WorldHeightHandler.getMaxWorldHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinBiomeDecorator.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinBiomeDecorator.java
@@ -1,0 +1,18 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.world.biome.BiomeDecorator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(BiomeDecorator.class)
+public class MixinBiomeDecorator {
+
+    // Ore gen height needs some adjustment
+    @ModifyConstant(method = "generateOres", constant = { @Constant(intValue = 0), @Constant(intValue = 256), @Constant(intValue = 128), @Constant(intValue = 64), @Constant(intValue = 32), @Constant(intValue = 16) })
+    private int increaseByWorldHeightOffset(int original) {
+
+        return original + WorldHeightHandler.getWorldHeightOffset();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinMapGenCaves.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinMapGenCaves.java
@@ -1,0 +1,17 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.world.gen.MapGenCaves;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MapGenCaves.class)
+public class MixinMapGenCaves {
+
+    @ModifyConstant(method = "func_151538_a", constant = @Constant(intValue = 120))
+    private int higherCaveStartPoint(int original) {
+
+        return original + WorldHeightHandler.getWorldHeightOffset();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenCanopyTree.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenCanopyTree.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenCanopyTree;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenCanopyTree.class)
+public class MixinWorldGenCanopyTree {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenDoublePlant.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenDoublePlant.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenDoublePlant;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenDoublePlant.class)
+public class MixinWorldGenDoublePlant {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 254))
+    private int getIncreasedWorldHeightMinusTwo(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight() - 2;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenFlowers.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenFlowers.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenFlowers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenFlowers.class)
+public class MixinWorldGenFlowers {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 255))
+    private int getIncreasedWorldHeightMinusOne(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight() - 1;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenForest.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenForest.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenForest;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenForest.class)
+public class MixinWorldGenForest {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenHugeTrees.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenHugeTrees.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenHugeTrees;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenHugeTrees.class)
+public class MixinWorldGenHugeTrees {
+
+    @ModifyConstant(method = "func_150536_b", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z, int size) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSavannaTree.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSavannaTree.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenSavannaTree;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenSavannaTree.class)
+public class MixinWorldGenSavannaTree {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSpikes.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSpikes.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenSpikes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenSpikes.class)
+public class MixinWorldGenSpikes {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSwamp.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenSwamp.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenSwamp;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenSwamp.class)
+public class MixinWorldGenSwamp {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTaiga1.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTaiga1.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenTaiga1;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenTaiga1.class)
+public class MixinWorldGenTaiga1 {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTaiga2.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTaiga2.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenTaiga2;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenTaiga2.class)
+public class MixinWorldGenTaiga2 {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTrees.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/worldheight/worldgen/MixinWorldGenTrees.java
@@ -1,0 +1,19 @@
+package ganymedes01.etfuturum.mixins.early.worldheight.worldgen;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenTrees;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.util.Random;
+
+@Mixin(WorldGenTrees.class)
+public class MixinWorldGenTrees {
+
+    @ModifyConstant(method = "generate", constant = @Constant(intValue = 256))
+    private int getIncreasedWorldHeight(int original, World world, Random random, int x, int y, int z) {
+
+        return world.provider.getHeight();
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/world/WorldHeightHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/world/WorldHeightHandler.java
@@ -1,0 +1,514 @@
+package ganymedes01.etfuturum.world;
+
+import cpw.mods.fml.common.ZipperUtil;
+import ganymedes01.etfuturum.Tags;
+import ganymedes01.etfuturum.client.gui.GuiWorldHeightMigrationProgress;
+import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
+import ganymedes01.etfuturum.lib.Reference;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagDouble;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.storage.RegionFile;
+import net.minecraft.world.storage.MapStorage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.*;
+
+public class WorldHeightHandler {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private static boolean isIncreasedWorldHeightEnabled = false;
+    private static int maxWorldHeight = 512;
+    private static int chunkSections = 32;
+    private static int worldHeightOffset = 64;
+
+    public static void initWorldHeightHandler() {
+
+        int max = ConfigExperiments.maxWorldHeight;
+
+        isIncreasedWorldHeightEnabled = ConfigExperiments.enableIncreasedWorldHeight;
+        maxWorldHeight = max;
+        chunkSections = maxWorldHeight >> 4;
+
+        if(chunkSections < 32 && maxWorldHeight % 16 != 0) chunkSections++;
+
+        if(worldHeightOffset >= -128 && worldHeightOffset <= 128) {
+
+            worldHeightOffset = ConfigExperiments.worldHeightOffset >> 4 << 4;
+        }
+    }
+
+    public static boolean isIncreasedWorldHeightEnabled() {
+
+        return isIncreasedWorldHeightEnabled;
+    }
+
+    public static int getMaxWorldHeight() {
+
+        return isIncreasedWorldHeightEnabled() ? maxWorldHeight : 256;
+    }
+
+    public static int getChunkSections() {
+
+        return isIncreasedWorldHeightEnabled() ? chunkSections : 16;
+    }
+
+    public static int getWorldHeightOffset() {
+
+        return worldHeightOffset;
+    }
+
+    public static class WorldHeightMigrator {
+
+        public static boolean migrateWorldHeight(File worldDir) throws IOException {
+
+            return migrateWorldHeightWithProgress(worldDir, worldHeightOffset, null);
+        }
+
+        public static boolean migrateWorldHeightWithProgress(File worldDir, GuiWorldHeightMigrationProgress gui) throws IOException {
+
+            return migrateWorldHeightWithProgress(worldDir, worldHeightOffset, gui);
+        }
+
+        /*
+            This moves the y level for all blocks in the world up and down for the specified offset.
+         */
+        public static boolean migrateWorldHeightWithProgress(File worldDir, int offset, GuiWorldHeightMigrationProgress gui) throws IOException {
+
+            int migratedChunks = 0;
+
+            logger.info("[World Height Migration] Started to create a backup of {}.", worldDir.getName());
+
+            NBTTagCompound leveldatNBT = CompressedStreamTools.readCompressed(new FileInputStream(new File(worldDir, "level.dat")));
+
+            if (gui != null) {
+
+                gui.setProgress(-1);
+                gui.setMaxProgress(0);
+                gui.setProgressText(StatCollector.translateToLocal("gui.worldheight.migration.backup"));
+            }
+
+            ZipperUtil.backupWorld(worldDir.getName());
+
+            logger.info("[World Height Migration] Successfully created a backup of {}. Continue with height migration.", worldDir.getName());
+            logger.info("[World Height Migration] Starting to migrate the chunks of World {} to height offset {}.", worldDir.getName(), offset);
+
+            if (gui != null) { gui.setProgressText(StatCollector.translateToLocal("gui.worldheight.migration.region")); }
+
+            File regionDir = new File(worldDir, "region");
+
+            if(!regionDir.exists() || !regionDir.isDirectory()) {
+
+                throw new IOException("The world region folder does not exist or is not a directory: " + regionDir.getAbsolutePath());
+            }
+
+            File[] regionFiles = regionDir.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+
+                    return name.startsWith("r.") && name.endsWith(".mca");
+                }
+            });
+
+            if(regionFiles == null || regionFiles.length == 0) {
+
+                throw new IOException("Failed to find region files in " +  regionDir.getAbsolutePath());
+            }
+
+            logger.info("[World Height Migration] Found {} region files in world {}", regionFiles.length, worldDir.getName());
+
+            if (gui != null) {
+
+                gui.setProgress(0);
+                gui.setMaxProgress(regionFiles.length);
+            }
+
+            for(int i = 0; i < regionFiles.length; i++) {
+
+                migratedChunks += migrateRegionFile(regionFiles[i], offset);
+
+                if (gui != null) { gui.setProgress(i + 1); }
+            }
+
+            logger.info("[World Height Migration] Successfully migrated {} chunks in world {}", migratedChunks, worldDir.getName());
+
+            if (gui != null) { gui.setProgressText(StatCollector.translateToLocal("gui.worldheight.migration.players")); }
+
+            shiftPlayersWithProgress(worldDir, offset, leveldatNBT, gui);
+
+            if (gui != null) {
+
+                gui.setProgress(-1);
+                gui.setMaxProgress(0);
+                gui.setProgressText(StatCollector.translateToLocal("gui.worldheight.migration.spawnpoint"));
+            }
+
+            shiftSpawnPoint(worldDir, offset, leveldatNBT);
+
+            NBTTagCompound data = leveldatNBT.getCompoundTag(Reference.MOD_ID + ".container");
+
+            data.setBoolean(NBTTags.HEIGHT_MIGRATED.toString(), true);
+            data.setInteger(NBTTags.HEIGHT_OFFSET.toString(), WorldHeightHandler.getWorldHeightOffset());
+            data.setBoolean(NBTTags.HEIGHT_ENABLED.toString(), true);
+            data.setInteger(NBTTags.MAX_HEIGHT.toString(), WorldHeightHandler.getMaxWorldHeight());
+
+            CompressedStreamTools.writeCompressed(leveldatNBT, new FileOutputStream(new File(worldDir, "level.dat")));
+
+            if (gui != null) {
+
+                gui.setProgress(-1);
+                gui.setMaxProgress(1);
+                gui.setProgressText(StatCollector.translateToLocal("gui.worldheight.migration.successful"));
+                gui.setSuccessful((byte) 1);
+            }
+
+            return true;
+        }
+
+        private static int migrateRegionFile(File regionFile, int offset) throws IOException {
+
+            int migratedChunks = 0;
+
+            RegionFile region = new RegionFile(regionFile);
+
+            for(int xChunk = 0; xChunk < 32; xChunk++) {
+
+                for (int zChunk = 0; zChunk < 32; zChunk++) {
+
+                    DataInputStream chunkIn = region.getChunkDataInputStream(xChunk, zChunk);
+
+                    if (chunkIn == null) { continue; }
+
+                    NBTTagCompound regionNBT;
+
+                    regionNBT = CompressedStreamTools.read(chunkIn);
+
+                    chunkIn.close();
+
+                    if (!regionNBT.hasKey("Level")) { continue; }
+
+                    NBTTagCompound level = regionNBT.getCompoundTag("Level");
+
+                    shiftSections(level, offset);
+                    shiftTileEntities(level, offset);
+                    shiftEntities(level, offset);
+                    shiftHeightMap(level, offset);
+
+                    // Mark dirty for creation of a new lightmap
+                    level.setBoolean("LightPopulated", true);
+
+                    DataOutputStream chunkOut = region.getChunkDataOutputStream(xChunk, zChunk);
+                    CompressedStreamTools.write(regionNBT, chunkOut);
+                    chunkOut.close();
+
+                    migratedChunks++;
+                }
+            }
+
+            region.close();
+
+            logger.info("[World Height Migration] Migrated {} chunks in region file {}.", migratedChunks, regionFile.getName());
+
+            return migratedChunks;
+        }
+
+        private static void shiftSections(NBTTagCompound level, int offset) throws IllegalStateException {
+
+            if(!level.hasKey("Sections")) { return; }
+
+            NBTTagList sections = level.getTagList("Sections", 10);
+
+            for(int i = 0; i < sections.tagCount(); i++) {
+
+                NBTTagCompound section = sections.getCompoundTagAt(i);
+
+                if(!section.hasKey("Y")) { continue; }
+
+                int oldSection = section.getByte("Y") & 255;
+                int newSection = oldSection + (offset >> 4);
+
+                if(newSection < 0 || newSection > 32) {
+
+                    throw new IllegalStateException("[World Height Migration] Section Y out of range after migration from " + oldSection + " to " + newSection);
+                }
+
+                section.setByte("Y", (byte) newSection);
+            }
+        }
+
+        private static void shiftTileEntities(NBTTagCompound level, int offset) {
+
+            if(!level.hasKey("TileEntities")) { return; }
+
+            NBTTagList tileEntitiesNBT = level.getTagList("TileEntities", 10);
+
+            for(int i = 0; i < tileEntitiesNBT.tagCount(); i++) {
+
+                NBTTagCompound tileEntityNBT = tileEntitiesNBT.getCompoundTagAt(i);
+
+                if(tileEntityNBT.hasKey("y")) {
+
+                    tileEntityNBT.setInteger("y", tileEntityNBT.getInteger("y") + offset);
+                }
+            }
+        }
+
+        private static void shiftEntities(NBTTagCompound level, int offset) {
+
+            if(!level.hasKey("Entities")) { return; }
+
+            NBTTagList entities = level.getTagList("Entities", 10);
+
+            for(int i = 0; i < entities.tagCount(); i++) {
+
+                NBTTagCompound entityNBT = entities.getCompoundTagAt(i);
+
+                if(entityNBT.hasKey("Pos")) {
+
+                    NBTTagList entityPos = entityNBT.getTagList("Pos", 6);
+
+                    if(entityPos.tagCount() >= 3) {
+
+                        double posX = entityPos.func_150309_d(0);
+                        double posY = entityPos.func_150309_d(1);
+                        double posZ = entityPos.func_150309_d(2);
+
+                        NBTTagList newEntityPos = new NBTTagList();
+                        newEntityPos.appendTag(new NBTTagDouble(posX));
+                        newEntityPos.appendTag(new NBTTagDouble(posY + offset));
+                        newEntityPos.appendTag(new NBTTagDouble(posZ));
+
+                        entityNBT.setTag("Pos", newEntityPos);
+
+                        if(entityNBT.hasKey("TileY")) {
+
+                            int oldTileY = entityNBT.getInteger("TileY");
+
+                            entityNBT.setInteger("TileY", oldTileY + offset);
+                        }
+
+                        if(entityNBT.hasKey("SleepingY")) {
+
+                            int oldSleepingY = entityNBT.getInteger("SleepingY");
+
+                            entityNBT.setInteger("SleepingY", oldSleepingY + offset);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void shiftHeightMap(NBTTagCompound level, int offset) {
+
+            if(!level.hasKey("HeightMap")) { return; }
+
+            int[] heightMap = level.getIntArray("HeightMap");
+
+            if(heightMap == null || heightMap.length == 0) { return; }
+
+            for(int i = 0; i < heightMap.length; i++) {
+
+                if(heightMap[i] > 0) {
+
+                    heightMap[i] += offset;
+                }
+            }
+
+            level.setIntArray("HeightMap", heightMap);
+        }
+
+        private static void shiftPlayersWithProgress(File worldDir, int offset, NBTTagCompound leveldatNBT, GuiWorldHeightMigrationProgress gui) throws IOException {
+
+            int playersMigrated = 0;
+
+            if (gui != null) { gui.setProgress(0); }
+
+            File playerDir = new File(worldDir, "playerdata");
+
+            if(!playerDir.isDirectory()) { return; }
+
+            File[] playerFiles = playerDir.listFiles();
+
+            if(playerFiles == null) { return; }
+
+            if (gui != null) { gui.setMaxProgress(playerFiles.length + 1); }
+
+            for(int i = 0; i < playerFiles.length; i++) {
+
+                if(!playerFiles[i].getName().endsWith(".dat")) { continue; }
+
+                NBTTagCompound playerNBT;
+
+                try {
+
+                    playerNBT = CompressedStreamTools.readCompressed(new FileInputStream(playerFiles[i]));
+
+                } catch (IOException e){
+
+                    logger.warn("[World Height Migration] There appears to be a problem reading the player file {}.", playerFiles[i].getAbsolutePath());
+
+                    continue;
+                }
+
+                if(playerNBT == null) { continue; }
+
+                if(playerNBT.hasKey("Pos")) {
+
+                    NBTTagList playerPos = playerNBT.getTagList("Pos", 6);
+
+                    if (playerPos.tagCount() >= 3) {
+
+                        NBTTagList newPlayerPos = new NBTTagList();
+                        newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(0)));
+                        newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(1) + offset));
+                        newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(2)));
+
+                        playerNBT.setTag("Pos", newPlayerPos);
+                    }
+                }
+
+                if(playerNBT.hasKey("SpawnY")) {
+
+                    playerNBT.setInteger("SpawnY", playerNBT.getInteger("SpawnY") + offset);
+                }
+
+                if(playerNBT.hasKey("Spawns")) {
+
+                    NBTTagList spawnList = playerNBT.getTagList("Spawns", 10);
+                    NBTTagList newSpawnList = new NBTTagList();
+
+                    for (int k = 0; k < spawnList.tagCount(); k++) {
+
+                        NBTTagCompound playerSpawn = spawnList.getCompoundTagAt(k);
+
+                        if (playerSpawn.getInteger("Dim") == 0) {
+
+                            playerSpawn.setInteger("SpawnY", playerSpawn.getInteger("SpawnY") + offset);
+                        }
+
+                        newSpawnList.appendTag(playerSpawn);
+                    }
+
+                    playerNBT.setTag("Spawns", newSpawnList);
+
+                    playersMigrated++;
+                }
+
+                CompressedStreamTools.writeCompressed(playerNBT, new FileOutputStream(playerFiles[i]));
+
+                if (gui != null) { gui.setProgress(i + 1); }
+            }
+
+            // For old singleplayer player data
+            if(leveldatNBT == null || !leveldatNBT.hasKey("Data")) {
+
+                throw new IOException("Could not find data in level.dat from world " + worldDir.getName() + "!");
+            }
+
+            NBTTagCompound data = leveldatNBT.getCompoundTag("Data");
+
+            if(data.hasKey("Player")) {
+
+                NBTTagCompound playerData = data.getCompoundTag("Player");
+                NBTTagList playerPos = playerData.getTagList("Pos", 6);
+
+                NBTTagList newPlayerPos = new NBTTagList();
+                newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(0)));
+                newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(1) + offset));
+                newPlayerPos.appendTag(new NBTTagDouble(playerPos.func_150309_d(2)));
+
+                playerData.setTag("Pos", newPlayerPos);
+
+                playersMigrated++;
+            }
+
+            logger.info("[World Height Migration] Successfully migrated the height of {} {}.", playersMigrated, playersMigrated > 1 ? "Players" : "Player");
+        }
+
+        private static void shiftSpawnPoint(File worldDir, int offset, NBTTagCompound leveldatNBT) throws IOException {
+
+            NBTTagCompound data = leveldatNBT.getCompoundTag("Data");
+
+            if(data.hasKey("SpawnY")) {
+
+                data.setInteger("SpawnY", data.getInteger("SpawnY") + offset);
+            }
+
+            logger.info("[World Height Migration] Successfully migrated the spawn point height.");
+        }
+
+        /*
+        0 = No Migration needed
+        1 = Migration upwards
+        2 = Migration downwards
+        3 = World gets smaller
+        4 = Increased World Height is disabled
+        */
+        public static int isMigrationNeeded(NBTTagCompound etfuturumNBT) {
+
+            if (WorldHeightHandler.isIncreasedWorldHeightEnabled()) {
+
+                if (etfuturumNBT.getBoolean(NBTTags.HEIGHT_NATURALLY.toString())) { return 0; }
+
+                if (etfuturumNBT.getBoolean(NBTTags.HEIGHT_MIGRATED.toString())) { return 0; }
+
+                if (etfuturumNBT.getInteger(NBTTags.MAX_HEIGHT.toString()) > WorldHeightHandler.getMaxWorldHeight()) {
+
+                    return 3;
+                }
+
+                if (WorldHeightHandler.getWorldHeightOffset() > 0) {
+
+                    return 1;
+
+                } else if (WorldHeightHandler.getWorldHeightOffset() < 0) {
+
+                    return 2;
+
+                } else {
+
+                    return 0;
+                }
+
+            } else {
+
+                if (etfuturumNBT.getBoolean(NBTTags.HEIGHT_ENABLED.toString())) {
+
+                    return 4;
+
+                } else {
+
+                    return 0;
+                }
+            }
+        }
+    }
+
+    public enum NBTTags {
+
+        HEIGHT_ENABLED("IncreasedHeightEnabled"),
+        HEIGHT_NATURALLY("IncreasedHeightNaturally"),
+        MOD_VERSION("EtFuturumVersion"),
+        MAX_HEIGHT("MaxWorldHeight"),
+        HEIGHT_MIGRATED("IncreasedHeightMigrated"),
+        HEIGHT_OFFSET("HeightOffset");
+
+        final String nbtTag;
+
+        NBTTags(String nbtTag) {
+
+            this.nbtTag = nbtTag;
+        }
+
+        @Override
+        public String toString() {
+
+            return nbtTag;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/world/generate/ChunkProviderIncreasedHeight.java
+++ b/src/main/java/ganymedes01/etfuturum/world/generate/ChunkProviderIncreasedHeight.java
@@ -1,0 +1,433 @@
+package ganymedes01.etfuturum.world.generate;
+
+import ganymedes01.etfuturum.world.WorldHeightHandler;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.*;
+import net.minecraft.world.gen.structure.MapGenMineshaft;
+import net.minecraft.world.gen.structure.MapGenScatteredFeature;
+import net.minecraft.world.gen.structure.MapGenStronghold;
+import net.minecraft.world.gen.structure.MapGenVillage;
+import net.minecraftforge.event.terraingen.TerrainGen;
+
+import java.util.Random;
+
+import static net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.*;
+
+public class ChunkProviderIncreasedHeight extends ChunkProviderGenerate {
+
+    private Random rand;
+
+    private NoiseGeneratorOctaves lowerNoiseGen;
+    private NoiseGeneratorOctaves upperNoiseGen;
+    private NoiseGeneratorOctaves mixedNoiseGen;
+    private NoiseGeneratorPerlin field_147430_m;
+    /** A NoiseGeneratorOctaves used in generating terrain */
+    public NoiseGeneratorOctaves noiseGen5;
+    /** A NoiseGeneratorOctaves used in generating terrain */
+    public NoiseGeneratorOctaves depthNoiseGen;
+    public NoiseGeneratorOctaves mobSpawnerNoise;
+    /** Reference to the World object. */
+    private World worldObj;
+    /** are map structures going to be generated (e.g. strongholds) */
+    private final boolean mapFeaturesEnabled;
+    private WorldType worldType;
+    private final double[] densityField;
+    private final float[] parabolicField;
+    private double[] stoneNoise = new double[256];
+    private MapGenBase caveGenerator = new MapGenCaves();
+    /** Holds Stronghold Generator */
+    private MapGenStronghold strongholdGenerator = new MapGenStronghold();
+    /** Holds Village Generator */
+    private MapGenVillage villageGenerator = new MapGenVillage();
+    /** Holds Mineshaft Generator */
+    private MapGenMineshaft mineshaftGenerator = new MapGenMineshaft();
+    private MapGenScatteredFeature scatteredFeatureGenerator = new MapGenScatteredFeature();
+    /** Holds ravine generator */
+    private MapGenBase ravineGenerator = new MapGenRavine();
+    /** The biomes that are used to generate the chunk */
+    private BiomeGenBase[] biomesForGeneration;
+    /** This field determines how the transition between lower and upper noise is handled **/
+    double[] blendNoiseField;
+    double[] lowerNoiseField;
+    double[] upperNoiseField;
+    /** This 2D noise field influences the approximate elevation of the terrain per x/z sample **/
+    double[] depthNoiseField;
+    int[][] field_73219_j = new int[32][32];
+
+    {
+        caveGenerator = TerrainGen.getModdedMapGen(caveGenerator, CAVE);
+        strongholdGenerator = (MapGenStronghold) TerrainGen.getModdedMapGen(strongholdGenerator, STRONGHOLD);
+        villageGenerator = (MapGenVillage) TerrainGen.getModdedMapGen(villageGenerator, VILLAGE);
+        mineshaftGenerator = (MapGenMineshaft) TerrainGen.getModdedMapGen(mineshaftGenerator, MINESHAFT);
+        scatteredFeatureGenerator = (MapGenScatteredFeature) TerrainGen.getModdedMapGen(scatteredFeatureGenerator, SCATTERED_FEATURE);
+        ravineGenerator = TerrainGen.getModdedMapGen(ravineGenerator, RAVINE);
+    }
+
+    public ChunkProviderIncreasedHeight(World world, long seed, boolean mapFeatures) {
+
+        super(world, seed, mapFeatures);
+
+        this.worldObj = world;
+        this.mapFeaturesEnabled = mapFeatures;
+        this.worldType = world.getWorldInfo().getTerrainType();
+        this.rand = new Random(seed);
+        this.lowerNoiseGen = new NoiseGeneratorOctaves(this.rand, 16);
+        this.upperNoiseGen = new NoiseGeneratorOctaves(this.rand, 16);
+        this.mixedNoiseGen = new NoiseGeneratorOctaves(this.rand, 8);
+        this.field_147430_m = new NoiseGeneratorPerlin(this.rand, 4);
+        this.noiseGen5 = new NoiseGeneratorOctaves(this.rand, 10);
+        this.depthNoiseGen = new NoiseGeneratorOctaves(this.rand, 16);
+        this.mobSpawnerNoise = new NoiseGeneratorOctaves(this.rand, 8);
+        // 5 x 5 x 65 = 1625
+        this.densityField = new double[1625];
+        this.parabolicField = new float[25];
+
+        for (int j = -2; j <= 2; ++j)
+        {
+            for (int k = -2; k <= 2; ++k)
+            {
+                float f = 10.0F / MathHelper.sqrt_float((float)(j * j + k * k) + 0.2F);
+                this.parabolicField[j + 2 + (k + 2) * 5] = f;
+            }
+        }
+
+        NoiseGenerator[] noiseGens = {lowerNoiseGen, upperNoiseGen, mixedNoiseGen, field_147430_m, noiseGen5, depthNoiseGen, mobSpawnerNoise};
+        noiseGens = TerrainGen.getModdedNoiseGenerators(world, this.rand, noiseGens);
+        this.lowerNoiseGen = (NoiseGeneratorOctaves)noiseGens[0];
+        this.upperNoiseGen = (NoiseGeneratorOctaves)noiseGens[1];
+        this.mixedNoiseGen = (NoiseGeneratorOctaves)noiseGens[2];
+        this.field_147430_m = (NoiseGeneratorPerlin)noiseGens[3];
+        this.noiseGen5 = (NoiseGeneratorOctaves)noiseGens[4];
+        this.depthNoiseGen = (NoiseGeneratorOctaves)noiseGens[5];
+        this.mobSpawnerNoise = (NoiseGeneratorOctaves)noiseGens[6];
+    }
+
+    /**
+     * Will return back a chunk, if it doesn't exist and its not a MP client it will generates all the blocks for the
+     * specified chunk from the map seed and chunk seed
+     */
+    @Override
+    public Chunk provideChunk(int chunkX, int chunkZ) {
+
+        this.rand.setSeed((long)chunkX * 341873128712L + (long)chunkZ * 132897987541L);
+
+        //Block[] blocks = new Block[16 * 16 * WorldHeightHandler.getMaxWorldGenHeight()];
+        //byte[] abyte = new byte[16 * 16 * WorldHeightHandler.getMaxWorldGenHeight()];
+        Block[] blocks = new Block[65536];
+        byte[] abyte = new byte[65536];
+
+        this.generateBaseTerrain(chunkX, chunkZ, blocks);
+        this.biomesForGeneration = this.worldObj.getWorldChunkManager().loadBlockGeneratorData(this.biomesForGeneration, chunkX * 16, chunkZ * 16, 16, 16);
+        this.replaceBlocksForBiome(chunkX, chunkZ, blocks, abyte, this.biomesForGeneration);
+        this.caveGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+        this.ravineGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+
+        if (this.mapFeaturesEnabled)
+        {
+            this.mineshaftGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+            this.villageGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+            this.strongholdGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+            this.scatteredFeatureGenerator.func_151539_a(this, this.worldObj, chunkX, chunkZ, blocks);
+        }
+
+        Chunk chunk = new Chunk(this.worldObj, blocks, abyte, chunkX, chunkZ);
+        byte[] abyte1 = chunk.getBiomeArray();
+
+        for (int k = 0; k < abyte1.length; ++k)
+        {
+            abyte1[k] = (byte)this.biomesForGeneration[k].biomeID;
+        }
+
+        chunk.generateSkylightMap();
+        return chunk;
+    }
+
+    /*
+    Generates a base terrain of stone.
+    And oceans for every empty (Air) block below the sealevel.
+     */
+    protected void generateBaseTerrain(int chunkX, int chunkZ, Block[] blocks) {
+
+        byte seaLevel = (byte) (63 + WorldHeightHandler.getWorldHeightOffset());
+        //byte verticalCells = (byte) (WorldHeightHandler.getMaxWorldHeight() >> 3);
+        byte verticalCells = 32;
+
+        // Gets biomes for an area of 10x10 in a 4x4 downsampled resolution
+        this.biomesForGeneration = this.worldObj.getWorldChunkManager().getBiomesForGeneration(this.biomesForGeneration, chunkX * 4 - 2, chunkZ * 4 - 2, 10, 10);
+
+        this.generateDensityField(chunkX * 4, 0, chunkZ * 4);
+
+        // Divides the chunk in 4x4 horizontal "cells"
+        for (int cellX = 0; cellX < 4; ++cellX) {
+
+            // 5 because there are exactly 4 gaps between 5 points
+            int noiseX = cellX * 5;
+            int noiseX1 = (cellX + 1) * 5;
+
+            for (int cellZ = 0; cellZ < 4; ++cellZ) {
+
+                // Four corner points in the coarse density field for this horizontal cell
+                int columnx0z0 = (noiseX + cellZ) * (verticalCells + 1);
+                int columnx0z1 = (noiseX + cellZ + 1) * (verticalCells + 1);
+                int columnx1z0 = (noiseX1 + cellZ) * (verticalCells + 1);
+                int columnx1z1 = (noiseX1 + cellZ + 1) * (verticalCells + 1);
+
+                // The density field has 33 vertical points with 32 gaps and and every vertical cell has 8 blocks (256 / 8)
+                for (int cellY = 0; cellY < verticalCells; ++cellY) {
+
+                    // Vertical interpolation between two Y points
+                    // 1 / 8 = 0.125 because one vertical cell has 8 blocks
+                    double verticalInterpolation = 0.125D;
+
+                    // Density values at the 4 lower corners of the current 3D cell
+                    double density00 = this.densityField[columnx0z0 + cellY];
+                    double density01 = this.densityField[columnx0z1 + cellY];
+                    double density10 = this.densityField[columnx1z0 + cellY];
+                    double density11 = this.densityField[columnx1z1 + cellY];
+
+                    // How much each parameter changes per vertical substep (a vertical substep is one block)
+                    double densityYStep00 = (this.densityField[columnx0z0 + cellY + 1] - density00) * verticalInterpolation;
+                    double densityYStep01 = (this.densityField[columnx0z1 + cellY + 1] - density01) * verticalInterpolation;
+                    double densityYStep10 = (this.densityField[columnx1z0 + cellY + 1] - density10) * verticalInterpolation;
+                    double densitiyYStep11 = (this.densityField[columnx1z1 + cellY + 1] - density11) * verticalInterpolation;
+
+                    // 8 vertical substeps per vertical cell
+                    for (int subStepY = 0; subStepY < 8; ++subStepY) {
+
+                        // Horizontal interpolation in x direction
+                        // 1 / 4 = 0.25 because one horizontal cell has 4 blocks in x direction
+                        double horizontalInterpolationX = 0.25D;
+
+                        // Start values left/right for the y cell
+                        double densityLeft = density00;
+                        double densityRight = density01;
+
+                        // How much each parameter changes per horizontal substep
+                        double densityXStepLeft = (density10 - density00) * horizontalInterpolationX;
+                        double densityXStepRight = (density11 - density01) * horizontalInterpolationX;
+
+                        // 4 horizontal substeps per horizontal x cell
+                        for (int subStepX = 0; subStepX < 4; ++subStepX) {
+
+                            // Blockarray index for the starting point of the current Z column
+                            //int blockIndex = ((cellX * 4 + subStepX) * 16 + (cellZ * 4)) * WorldHeightHandler.getMaxWorldGenHeight() + (cellY * 8 + subStepY);
+                            int blockIndex = ((subStepX + cellX * 4) << 12) | ((cellZ * 4) << 8) | (cellY * 8 + subStepY);
+
+                            // Step size for Z in the array
+                            // If you increment z by 1, it advances by 256.
+                            //short zStride = (short) (WorldHeightHandler.getMaxWorldGenHeight());
+                            short zStride = 256;
+
+                            // -zStride because in the inner loop it will be added first
+                            blockIndex -= zStride;
+
+                            // Horizontal interpolation in z direction
+                            // 1 / 4 = 0.25 because one horizontal cell has 4 blocks in z direction
+                            double horizontalInterpolationZ = 0.25D;
+
+                            double densityZStep = (densityRight - densityLeft) * horizontalInterpolationZ;
+
+                            // Set the starting value so that in the first loop iteration,
+                            // the first valid point is generated immediately after the += operator.
+                            double density = densityLeft - densityZStep;
+
+                            // 4 horizontal substeps per horizontal z cell
+                            for (int subStepZ = 0; subStepZ < 4; ++subStepZ) {
+
+                                // Block has density = stone
+                                if ((density += densityZStep) > 0.0D) {
+
+                                    blocks[blockIndex += zStride] = Blocks.stone;
+
+                                // No density (air) below sealevel = water
+                                } else if (cellY * 8 + subStepY < seaLevel) {
+
+                                    blocks[blockIndex += zStride] = Blocks.water;
+
+                                // No density = air
+                                } else {
+
+                                    blocks[blockIndex += zStride] = null;
+                                }
+                            }
+
+                            // For the next x step
+                            densityLeft += densityXStepLeft;
+                            densityRight += densityXStepRight;
+                        }
+
+                        // For the next vertical substep
+                        density00 += densityYStep00;
+                        density01 += densityYStep01;
+                        density10 += densityYStep10;
+                        density11 += densitiyYStep11;
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+    Calculates a coarse 3D density field for this chunk area
+     */
+    protected void generateDensityField(int xStart, int yStart, int zStart) {
+
+        // A rough approximation of the local elevation. Not the actual mountain shpae, but rather an additional modulation
+        this.depthNoiseField = this.depthNoiseGen.generateNoiseOctaves(this.depthNoiseField, xStart, zStart, 5, 5, 200.0D, 200.0D, 0.5D);
+        // How much mix the lower and upper noise
+        this.blendNoiseField = this.mixedNoiseGen.generateNoiseOctaves(this.blendNoiseField, xStart, yStart, zStart, 5, 33, 5, 8.555150000000001D, 4.277575000000001D, 8.555150000000001D);
+        this.lowerNoiseField = this.lowerNoiseGen.generateNoiseOctaves(this.lowerNoiseField, xStart, yStart, zStart, 5, 33, 5, 684.412D, 684.412D, 684.412D);
+        this.upperNoiseField = this.upperNoiseGen.generateNoiseOctaves(this.upperNoiseField, xStart, yStart, zStart, 5, 33, 5, 684.412D, 684.412D, 684.412D);
+
+        // Linear index into the final 3D densityField
+        int densityIndex = 0;
+        // Linear index into the final 2D-depth-noise parabolicField
+        int depthNoiseIndex = 0;
+        // Base terrain level in the approximate sample area
+        double baseTerrainLevel = 8.5D;
+
+        // The horizontal density field has a size of 5x5
+        for (int sampleX = 0; sampleX < 5; ++sampleX) {
+
+            for (int sampleZ = 0; sampleZ < 5; ++sampleZ) {
+
+                // These three variables calculate biome-weighted averages:
+                float accumulatedHeightVariation = 0.0F;
+                float accumulatedRootHeight = 0.0F;
+                float accumulatedWeight = 0.0F;
+
+                // Radius for biome-blending (-2 .. +2 = 5x5 area)
+                byte biomeBlendRadius = 2;
+
+                // The central biome for this sample
+                BiomeGenBase centralBiome = this.biomesForGeneration[sampleX + 2 + (sampleZ + 2) * 10];
+
+                for (int biomeOffsetX = -biomeBlendRadius; biomeOffsetX <= biomeBlendRadius; ++biomeOffsetX) {
+
+                    for (int biomeOffsetZ = -biomeBlendRadius; biomeOffsetZ <= biomeBlendRadius; ++biomeOffsetZ) {
+
+                        BiomeGenBase nearbyBiomes = this.biomesForGeneration[sampleX + biomeOffsetX + 2 + (sampleZ + biomeOffsetZ + 2) * 10];
+
+                        // Coarse terrain base layer
+                        float nearbyRootHeight = nearbyBiomes.rootHeight;
+                        // How hilly or steep the terrain is
+                        float nearbyHeightVariation = nearbyBiomes.heightVariation;
+
+                        // WorldType Amplified makes height variations way more extreme
+                        if (this.worldType == WorldType.AMPLIFIED && nearbyRootHeight > 0.0F) {
+
+                            nearbyRootHeight = 1.0F + nearbyRootHeight * 2.0F;
+                            nearbyHeightVariation = 1.0F + nearbyHeightVariation * 4.0F;
+                        }
+                        // Weighted values from parabolicField
+                        // The center has more influence than more distant biomes
+                        // The expression /(nearbyRootHeight + 2) slightly reduces the significance of tall biomes
+                        float biomeWeight = this.parabolicField[biomeOffsetX + 2 + (biomeOffsetZ + 2) * 5] / (nearbyRootHeight + 2.0F);
+
+                        // If the adjacent biome is higher than the center, its influence is halved.
+                        // This prevents high biomes from having too strong an influence on lower ones.
+                        if (nearbyBiomes.rootHeight > centralBiome.rootHeight) {
+
+                            biomeWeight /= 2.0F;
+                        }
+
+                        accumulatedHeightVariation += nearbyHeightVariation * biomeWeight;
+                        accumulatedRootHeight += nearbyRootHeight * biomeWeight;
+                        accumulatedWeight += biomeWeight;
+                    }
+                }
+
+                // Normalize weighted averages
+                accumulatedHeightVariation /= accumulatedWeight;
+                accumulatedRootHeight /= accumulatedWeight;
+                // Height variation gets a bit smoothed out
+                accumulatedHeightVariation = accumulatedHeightVariation * 0.9F + 0.1F;
+                // Root height gets translated into the vertical logic of the terrain generator
+                accumulatedRootHeight = (accumulatedRootHeight * 4.0F - 1.0F) / 8.0F;
+
+                // The 2D-depth-noise-field adjusts the base height again
+                double depthNoise = this.depthNoiseField[depthNoiseIndex] / 8000.0D;
+
+                if (depthNoise < 0.0D) {
+
+                    depthNoise = -depthNoise * 0.3D;
+                }
+
+                depthNoise = depthNoise * 3.0D - 2.0D;
+
+                if (depthNoise < 0.0D) {
+
+                    depthNoise /= 2.0D;
+
+                    if (depthNoise < -1.0D) {
+
+                        depthNoise = -1.0D;
+                    }
+
+                    depthNoise /= 1.4D;
+                    depthNoise /= 2.0D;
+                }
+                else
+                {
+                    if (depthNoise > 1.0D)
+                    {
+                        depthNoise = 1.0D;
+                    }
+
+                    depthNoise /= 8.0D;
+                }
+
+                ++depthNoiseIndex;
+                double blendedRootHeight = (double)accumulatedRootHeight;
+                double blendedHeightVariation = (double)accumulatedHeightVariation;
+                // Depth noise slightly affects the effective base level
+                blendedRootHeight += depthNoise * 0.2D;
+                // Some additional translation into terrain generator logic
+                blendedRootHeight = blendedRootHeight * 8.5D / 8.0D;
+
+                // This is the central vertical “target height” of the terrain in the coarse sample
+                // I use this to adjust the terrain height to get more space for the deep caves
+                double terrainCenterY = 8.5D + blendedRootHeight * 4.0D + (double) (WorldHeightHandler.getWorldHeightOffset() / 8);
+
+                for (int sampleY = 0; sampleY < 33; ++sampleY) {
+
+                    // This is the vertical distance from sampleY to the center of the terrain, scaled by the Height Variation.
+                    // The larger it is, the more the density is pulled downward, meaning there is more air and less rock.
+                    double verticalDistanceToTerrainCenter = ((double)sampleY - terrainCenterY) * 12.0D * 128.0D / 256.0D / blendedHeightVariation;
+
+                    // Below the terrain center (negative values), the curve is amplified to make the ground appear more solid.
+                    if (verticalDistanceToTerrainCenter < 0.0D) {
+
+                        verticalDistanceToTerrainCenter *= 4.0D;
+                    }
+
+                    // The big 3D noise fields
+                    double lowerNoise = this.lowerNoiseField[densityIndex] / 512.0D;
+                    double upperNoise = this.upperNoiseField[densityIndex] / 512.0D;
+
+                    // Blending between the two noise fields
+                    double blendNoise = (this.blendNoiseField[densityIndex] / 10.0D + 1.0D) / 2.0D;
+
+                    // Blending between lower an dupper noise and subtract the vertical gradient
+                    double density = MathHelper.denormalizeClamp(lowerNoise, upperNoise, blendNoise) - verticalDistanceToTerrainCenter;
+
+                    // This causes the top samples to be pulled toward the air. As a result, mountains end up well below the world limit.
+                    if (sampleY > 29) {
+
+                        double topFade = (double)((float)(sampleY - 29) / 3.0F);
+                        density = density * (1.0D - topFade) + -10.0D * topFade;
+                    }
+
+                    this.densityField[densityIndex] = density;
+                    ++densityIndex;
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/etfuturum/lang/en_US.lang
+++ b/src/main/resources/assets/etfuturum/lang/en_US.lang
@@ -46,6 +46,7 @@ container.etfuturum.chest_boat=Boat with Chest
 item.record.pigstep.desc=Lena Raine - Pigstep
 item.record.otherside.desc=Lena Raine - otherside
 
+gui.load_world=Load World
 gui.smithing.upgrade=Upgrade Gear
 gui.warn.continue=Continue...
 gui.warn.dismiss=Don't show me this again.
@@ -54,6 +55,22 @@ gui.warn.configSplit1=Due to the main Et Futurum Requiem config becoming very lo
 gui.warn.configSplit2=When you're done, you can delete or rename the old config file, or tick the box below to stop seeing this warning.
 gui.chat.update=%1$s version %2$s is available!
 gui.chat.update.download=Click here to download the update on %s!
+gui.worldheight.migration.title=World Height Migration
+gui.worldheight.button.migrate=Migrate World
+gui.worldheight.migration.confirm.description.upper=You have %s installed and enabled the Increase World Height feature with an height offset %s set for existing worlds. That means your complete world will be shifted up by this offset. This can serve various purposes i.e. its necessary to use the deep dark caves feature. This feature is experimental so please make a backup of your world (we will also make one for you but better have it twice).
+gui.worldheight.migration.confirm.description.lower=You have %s installed and enabled the Increase World Height feature with an height offset %s set for existing worlds. That means your complete world will be completely shifted down by this offset. Keep in mind that every block below Y:%s gets destroyed. This feature is experimental so please make a backup of your world (we will also make one for you but better have it twice).
+gui.worldheight.migration.confirm.description.disabling=You have disabled the Increase World Height feature but want to load a world with Increased World Height enabled and a max world height of %s. Everything above Y:256 gets destroyed. Please make a backup of your world (we will also make one for you but better have it twice).
+gui.worldheight.migration.confirm.description.smaller=You have %s installed and enabled the Increase World Height feature with an max world height set to %s. But you want to load a world with max world height of %s. Everything above Y:%s gets destroyed. Please make a backup of your world (we will also make one for you but better have it twice).
+gui.worldheight.migration.confirmation=Are you sure you want to migrate your world?
+gui.worldheight.migration.github=If you find any bugs please report it to:
+gui.worldheight.migration.inprogress=World gets migrated to the new height...
+gui.worldheight.migration.backup=Creating backup
+gui.worldheight.migration.region=Migrating region files
+gui.worldheight.migration.players=Migrating players
+gui.worldheight.migration.spawnpoint=Migrating spawn point
+gui.worldheight.migration.successful=Migration completed successfully!
+gui.worldheight.migration.failed=Migration failed!
+gui.worldheight.migration.failed.text=Maybe your world is now corrupt and you should use your backup. Please create an issue for this error at github and upload your fml logs.
 
 # Subtitles
 subtitle.game.tnt.primed=TNT primed


### PR DESCRIPTION
Hi,

I have made us able to raise the world build limit up to 512.

I need this because I want to backport the modern cave generation, and for this there must be more space below.

It works way better than initially expected but until now I categorize this as experimental.
I did not have tested mod compatibility and there could be bugs I have not found. 
Additionally I noticed that the performance has gotten worse, I had a bit more lag spikes than without this setting enabled.
I assume this happens because the renderer has now twice as many worldrenderer instances but out there are a lot of optimization mods and they should have already found a better solution than the old vanilla rendering.

Anyways I am appreciate every suggestions for improvement, I have made this in a few evenings after work.

This is the first step towards huge caves with biomes, warden, ancient cities and so on. But the tricky sutff is still to come :)
It could be necessary to completely rebuild the world generation system. If someone could assist me youre welcome.
Once its done we´ll have a very cool feature with huge potential for adapting other mods.
