### PR TITLE
allow 1.8 skin renderer to support delegated model bipeds to improve compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,30 +34,30 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.9.41:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.59:dev")
     compileOnly('curse.maven:rple-1050511:7358368') {transitive=false}
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive=false}
     compileOnly "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10:dev"
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev')
-    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.2:dev")
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.14-GTNH:dev')
+    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.7:dev")
     compileOnly "team.chisel:Chisel:2.9.5.12:deobf"
     compileOnly "team.chisel.ctmlib:CTMLib:MC1.7.10-1.4.1.5:deobf"
     compileOnly "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
     compileOnly "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
     compileOnly "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
-    compileOnly 'com.github.GTNewHorizons:ironchest:6.1.11'
+    compileOnly 'com.github.GTNewHorizons:ironchest:6.1.12'
     compileOnly 'curse.maven:applied-energistics-2-223794:2296430'
-    compileOnly 'com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.7-backhand'
-    compileOnly('com.github.GTNewHorizons:ForbiddenMagic:0.9.14-GTNH:dev') {
+    compileOnly 'com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.8-backhand'
+    compileOnly('com.github.GTNewHorizons:ForbiddenMagic:0.9.15-GTNH:dev') {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.35-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.62-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:Angelica:2.1.3:api") {
+    compileOnly("com.github.GTNewHorizons:Angelica:2.1.21:api") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:lwjgl3ify:3.0.15:api") {
+    compileOnly("com.github.GTNewHorizons:lwjgl3ify:3.0.16:api") {
         transitive = false
     }
     shadowImplementation('com.github.makamys:MCLib:0.3.7.7') {

--- a/src/main/java/ganymedes01/etfuturum/client/model/ModelPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/model/ModelPlayer.java
@@ -1,8 +1,14 @@
 package ganymedes01.etfuturum.client.model;
 
+import ganymedes01.etfuturum.client.skins.DelegatedModelBiped;
+import ganymedes01.etfuturum.client.skins.PlayerModelManager;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
+import org.lwjgl.opengl.GL11;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class ModelPlayer extends ModelBiped {
 
@@ -18,6 +24,8 @@ public class ModelPlayer extends ModelBiped {
 	public ModelRenderer bipedRightLegwear;
 	public ModelRenderer bipedBodyWear;
 	public boolean smallArms;
+
+	private Set<DelegatedModelBiped> delegates = new HashSet<>();
 
 	public ModelPlayer(float z, boolean smallArms) {
 		super(z, 0.0F, 64, 64);
@@ -75,11 +83,70 @@ public class ModelPlayer extends ModelBiped {
 		bipedBody.addChild(bipedBodyWear);
 	}
 
+	public void regenerateDelegates() {
+		this.delegates = PlayerModelManager.constructDelegatesFor(this);
+	}
+
+	public int getDelegatesCount() {
+		return delegates.size();
+	}
+
 	@Override
 	public void render(Entity p_render_1_, float p_render_2_, float p_render_3_, float p_render_4_, float p_render_5_, float p_render_6_, float p_render_7_) {
-		super.render(p_render_1_, p_render_2_, p_render_3_, p_render_4_, p_render_5_, p_render_6_, p_render_7_);
+		this.setRotationAngles(p_render_2_, p_render_3_, p_render_4_, p_render_5_, p_render_6_, p_render_7_, p_render_1_);
+		this.delegates.forEach(delegate -> delegate.preRender(p_render_1_, p_render_2_, p_render_3_, p_render_4_, p_render_5_, p_render_6_, p_render_7_));
 
-		if (smallArms)
-			bipedRightArm.rotationPointX += 1.0F;
+		// code stolen from original ModelBiped so that delegation can occur AFTER setRotationAngles but before body rendering
+		// alternative implementation is to add preRender delegate after setRotationAngles, but in the event that it's used elsewhere for some reason
+		// this approach is more "compatible"
+		if (this.isChild) {
+			float f6 = 2.0F;
+			GL11.glPushMatrix();
+			GL11.glScalef(1.5F / f6, 1.5F / f6, 1.5F / f6);
+			GL11.glTranslatef(0.0F, 16.0F * p_render_7_, 0.0F);
+			this.bipedHead.render(p_render_7_);
+			GL11.glPopMatrix();
+			GL11.glPushMatrix();
+			GL11.glScalef(1.0F / f6, 1.0F / f6, 1.0F / f6);
+			GL11.glTranslatef(0.0F, 24.0F * p_render_7_, 0.0F);
+			this.bipedBody.render(p_render_7_);
+			this.bipedRightArm.render(p_render_7_);
+			this.bipedLeftArm.render(p_render_7_);
+			this.bipedRightLeg.render(p_render_7_);
+			this.bipedLeftLeg.render(p_render_7_);
+			this.bipedHeadwear.render(p_render_7_);
+			GL11.glPopMatrix();
+		} else {
+			this.bipedHead.render(p_render_7_);
+			this.bipedBody.render(p_render_7_);
+			this.bipedRightArm.render(p_render_7_);
+			this.bipedLeftArm.render(p_render_7_);
+			this.bipedRightLeg.render(p_render_7_);
+			this.bipedLeftLeg.render(p_render_7_);
+			this.bipedHeadwear.render(p_render_7_);
+		}
+		// end stolen code
+		this.delegates.forEach(delegate -> delegate.postRender(p_render_1_, p_render_2_, p_render_3_, p_render_4_, p_render_5_, p_render_6_, p_render_7_));
+	}
+
+	@Override
+	public void setRotationAngles(float p_78087_1_, float p_78087_2_, float p_78087_3_, float p_78087_4_, float p_78087_5_, float p_78087_6_, Entity p_78087_7_) {
+		this.delegates.forEach(delegate -> delegate.preSetRotationAngles(p_78087_1_, p_78087_2_, p_78087_3_, p_78087_4_, p_78087_5_, p_78087_6_, p_78087_7_));
+		super.setRotationAngles(p_78087_1_, p_78087_2_, p_78087_3_, p_78087_4_, p_78087_5_, p_78087_6_, p_78087_7_);
+		this.delegates.forEach(delegate -> delegate.postSetRotationAngles(p_78087_1_, p_78087_2_, p_78087_3_, p_78087_4_, p_78087_5_, p_78087_6_, p_78087_7_));
+	}
+
+	@Override
+	public void renderEars(float p_78110_1_) {
+		this.delegates.forEach(delegate -> delegate.preRenderEars(p_78110_1_));
+		super.renderEars(p_78110_1_);
+		this.delegates.forEach(delegate -> delegate.postRenderEars(p_78110_1_));
+	}
+
+	@Override
+	public void renderCloak(float p_78111_1_) {
+		this.delegates.forEach(delegate -> delegate.preRenderCloak(p_78111_1_));
+		super.renderCloak(p_78111_1_);
+		this.delegates.forEach(delegate -> delegate.postRenderCloak(p_78111_1_));
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/client/skins/DelegatedModelBiped.java
+++ b/src/main/java/ganymedes01/etfuturum/client/skins/DelegatedModelBiped.java
@@ -1,0 +1,25 @@
+package ganymedes01.etfuturum.client.skins;
+
+import ganymedes01.etfuturum.client.model.ModelPlayer;
+import net.minecraft.entity.Entity;
+
+public abstract class DelegatedModelBiped {
+
+    protected final ModelPlayer model;
+
+    public DelegatedModelBiped(ModelPlayer model) {
+        this.model = model;
+    }
+
+    public void preRender(Entity p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_, float p_78088_6_, float p_78088_7_) { }
+    public void postRender(Entity p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_, float p_78088_6_, float p_78088_7_) { }
+
+    public void preSetRotationAngles(float p_78087_1_, float p_78087_2_, float p_78087_3_, float p_78087_4_, float p_78087_5_, float p_78087_6_, Entity p_78087_7_) { }
+    public void postSetRotationAngles(float p_78087_1_, float p_78087_2_, float p_78087_3_, float p_78087_4_, float p_78087_5_, float p_78087_6_, Entity p_78087_7_) { }
+
+    public void preRenderCloak(float p_78111_1_) { }
+    public void postRenderCloak(float p_78111_1_) { }
+
+    public void preRenderEars(float p_78110_1_) { }
+    public void postRenderEars(float p_78110_1_) { }
+}

--- a/src/main/java/ganymedes01/etfuturum/client/skins/NewRenderPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/skins/NewRenderPlayer.java
@@ -16,7 +16,12 @@ public class NewRenderPlayer extends RenderPlayer {
 	private boolean cachedAlex;
 
 	public static final ResourceLocation STEVE_SKIN = new ResourceLocation(Reference.MOD_ID, "textures/steve.png");
-	private static final ModelPlayer STEVE = new ModelPlayer(0.0F, false), ALEX = new ModelPlayer(0.0F, true);
+	private static final ModelPlayer STEVE = new ModelPlayer(0.0F, false),
+			STEVE_CHESTPLATE = new ModelPlayer(1.0F, false),
+			STEVE_ARMOR = new ModelPlayer(0.5F, false),
+			ALEX = new ModelPlayer(0.0F, true),
+			ALEX_CHESTPLATE = new ModelPlayer(1.0F, true),
+			ALEX_ARMOR = new ModelPlayer(0.5F, true);
 
 	public NewRenderPlayer() {
 		renderManager = RenderManager.instance;
@@ -27,6 +32,14 @@ public class NewRenderPlayer extends RenderPlayer {
 		if (cachedAlex != PlayerModelManager.isPlayerModelAlex(player)) {
 			cachedAlex = PlayerModelManager.isPlayerModelAlex(player);
 			mainModel = modelBipedMain = cachedAlex ? ALEX : STEVE;
+			modelArmorChestplate = cachedAlex ? ALEX_CHESTPLATE : STEVE_CHESTPLATE;
+			modelArmor = cachedAlex ? ALEX_ARMOR : STEVE_ARMOR;
+
+			if (PlayerModelManager.shouldRegenerateModelDelegates((ModelPlayer) mainModel)) {
+				((ModelPlayer) mainModel).regenerateDelegates();
+				((ModelPlayer) modelArmorChestplate).regenerateDelegates();
+				((ModelPlayer) modelArmor).regenerateDelegates();
+			}
 		}
 	}
 
@@ -39,6 +52,7 @@ public class NewRenderPlayer extends RenderPlayer {
 	@Override
 	public void doRender(AbstractClientPlayer player, double x, double y, double z, float someFloat, float partialTickTime) {
 		setModel(player);
+//		bindEntityTexture(player);
 		super.doRender(player, x, y, z, someFloat, partialTickTime);
 	}
 
@@ -49,7 +63,7 @@ public class NewRenderPlayer extends RenderPlayer {
 	}
 
 	@Override
-	protected ResourceLocation getEntityTexture(AbstractClientPlayer player) {
+	public ResourceLocation getEntityTexture(AbstractClientPlayer player) {
 		if (!ConfigFunctions.enablePlayerSkinOverlay || player.getLocationSkin() == null)
 			return super.getEntityTexture(player);
 		return new ResourceLocation(Reference.MOD_ID, player.getLocationSkin().getResourcePath());

--- a/src/main/java/ganymedes01/etfuturum/client/skins/PlayerModelManager.java
+++ b/src/main/java/ganymedes01/etfuturum/client/skins/PlayerModelManager.java
@@ -1,19 +1,57 @@
 package ganymedes01.etfuturum.client.skins;
 
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import cpw.mods.fml.client.registry.RenderingRegistry;
+import ganymedes01.etfuturum.client.model.ModelPlayer;
 import ganymedes01.etfuturum.lib.Reference;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.Constants;
 
-import java.util.Map;
-import java.util.UUID;
-import java.util.WeakHashMap;
+import java.io.File;
+import java.util.*;
+import java.util.function.Function;
 
 public class PlayerModelManager {
 
 	public static final String MODEL_KEY = Reference.MOD_ID + "_model";
 
 	public static Map<UUID, Boolean> alexCache = new WeakHashMap<>();
+
+	private static boolean enabled = false;
+	private static final Set<Function<ModelPlayer, DelegatedModelBiped>> DELEGATED_BIPED_MODEL_FACTORIES = new HashSet<>();
+
+	public static void registerModelDelegateFactory(Function<ModelPlayer, DelegatedModelBiped> delegatedModelBiped) {
+		DELEGATED_BIPED_MODEL_FACTORIES.add(delegatedModelBiped);
+	}
+
+	public static boolean shouldRegenerateModelDelegates(ModelPlayer model) {
+		return DELEGATED_BIPED_MODEL_FACTORIES.size() != model.getDelegatesCount(); // this is kinda lazy
+	}
+
+	public static Set<DelegatedModelBiped> constructDelegatesFor(ModelPlayer model) {
+		Set<DelegatedModelBiped> delegates = new HashSet<>();
+		for (Function<ModelPlayer, DelegatedModelBiped> factory : DELEGATED_BIPED_MODEL_FACTORIES) {
+			delegates.add(factory.apply(model));
+		}
+		return delegates;
+	}
+
+	public static boolean isEnabled() {
+		return enabled;
+	}
+
+	public static void enableNewModels() {
+		TextureManager texManager = Minecraft.getMinecraft().renderEngine;
+		File skinFolder = new File(Minecraft.getMinecraft().fileAssets, "skins");
+		MinecraftSessionService sessionService = Minecraft.getMinecraft().func_152347_ac(); // getSessionService
+		Minecraft.getMinecraft().field_152350_aA/*skinManager*/ = new NewSkinManager(Minecraft.getMinecraft().func_152342_ad()/*getSkinManager*/, texManager, skinFolder, sessionService);
+		RenderingRegistry.registerEntityRenderingHandler(EntityPlayer.class, new NewRenderPlayer());
+		enabled = true;
+	}
 
 	public static boolean isPlayerModelAlex(EntityPlayer player) {
 		if (player == null || player.getUniqueID() == null)

--- a/src/main/java/ganymedes01/etfuturum/core/proxy/ClientProxy.java
+++ b/src/main/java/ganymedes01/etfuturum/core/proxy/ClientProxy.java
@@ -1,6 +1,5 @@
 package ganymedes01.etfuturum.core.proxy;
 
-import com.mojang.authlib.minecraft.MinecraftSessionService;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
@@ -66,8 +65,7 @@ import ganymedes01.etfuturum.client.renderer.tileentity.TileEntityGatewayRendere
 import ganymedes01.etfuturum.client.renderer.tileentity.TileEntityNewBeaconRenderer;
 import ganymedes01.etfuturum.client.renderer.tileentity.TileEntityShulkerBoxRenderer;
 import ganymedes01.etfuturum.client.renderer.tileentity.TileEntityWoodSignRenderer;
-import ganymedes01.etfuturum.client.skins.NewRenderPlayer;
-import ganymedes01.etfuturum.client.skins.NewSkinManager;
+import ganymedes01.etfuturum.client.skins.PlayerModelManager;
 import ganymedes01.etfuturum.client.subtitle.GuiSubtitles;
 import ganymedes01.etfuturum.configuration.configs.ConfigFunctions;
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
@@ -100,19 +98,13 @@ import ganymedes01.etfuturum.tileentities.TileEntityShulkerBox;
 import ganymedes01.etfuturum.tileentities.TileEntityWoodSign;
 import ganymedes01.etfuturum.world.nether.biome.utils.BiomeFogEventHandler;
 import net.minecraft.block.BlockBed;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.entity.RenderManager;
-import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.entity.passive.EntityPig;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntitySkull;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
-
-import java.io.File;
 
 public class ClientProxy extends CommonProxy {
 
@@ -224,12 +216,7 @@ public class ClientProxy extends CommonProxy {
 //      }
 
 		if (ConfigFunctions.enablePlayerSkinOverlay) {
-			TextureManager texManager = Minecraft.getMinecraft().renderEngine;
-			File skinFolder = new File(Minecraft.getMinecraft().fileAssets, "skins");
-			MinecraftSessionService sessionService = Minecraft.getMinecraft().func_152347_ac(); // getSessionService
-			Minecraft.getMinecraft().field_152350_aA/*skinManager*/ = new NewSkinManager(Minecraft.getMinecraft().func_152342_ad()/*getSkinManager*/, texManager, skinFolder, sessionService);
-
-			RenderManager.instance.entityRenderMap.put(EntityPlayer.class, new NewRenderPlayer());
+			PlayerModelManager.enableNewModels();
 		}
 	}
 }


### PR DESCRIPTION
Doesn't improve compatibility by default, but provides the hooks necessary to address a bug with Galacticraft where the 1.8 skin overlay feature would conflict with it's custom player renderer for rendering the GC gear. This should not impact any functionality for this mod out of the gate, and might require further tweaking / additions as I solidify the Galacticraft compatibility fixes.

Galacticraft PR Implementing: https://github.com/GTNewHorizons/Galacticraft/pull/138

Neither rendering nor rendering optimization are my strong suits, please offer all improvements you can think of.