### PR TITLE
remove loaded chunks set in ServerEventHandler

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -4,6 +4,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.Event.Result;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -230,7 +231,6 @@ public class ServerEventHandler {
 		armorTracker.clear();
 		fallingConcreteBlocks.clear();
 		droppedEntityItems.invalidateAll();
-		loadedChunks.clear();
 	}
 
 	@SubscribeEvent
@@ -389,8 +389,6 @@ public class ServerEventHandler {
 	public void entityAdded(EntityJoinWorldEvent event) {
 		if (event.world.isRemote) return;
 
-		Chunk chunk = event.world.getChunkFromChunkCoords(MathHelper.floor_double(event.entity.posX) >> 4, MathHelper.floor_double(event.entity.posZ) >> 4);
-
 		String sound = "";
 		if (ConfigSounds.paintingItemFramePlacing && event.entity instanceof EntityItemFrame) {
 			sound = "item_frame";
@@ -409,49 +407,28 @@ public class ServerEventHandler {
 			if (event.entity.getClass() == EntityBoat.class) {
 				EntityNewBoat boat = new EntityNewBoat(event.world);
 				event.entity.rotationYaw += 90;
-				replaceEntity(event.entity, boat, event.world, chunk);
+				replaceEntity(event.entity, boat, event.world, event);
 				boat.setBoatType("minecraft", "oak");
-				event.setCanceled(true);
 				return;
 			}
 		}
 
 		if (ConfigEntities.enableVillagerZombies && event.entity.getClass() == EntityZombie.class && ((EntityZombie) event.entity).isVillager()) {
-			replaceEntity(event.entity, new EntityZombieVillager(event.world), event.world, chunk);
-			event.setCanceled(true);
+			replaceEntity(event.entity, new EntityZombieVillager(event.world), event.world, event);
 			return;
 		}
 
 		if (ConfigEntities.enableShearableSnowGolems && event.entity.getClass() == EntitySnowman.class) {
 			Entity entity = new EntityNewSnowGolem(event.world);
-			replaceEntity(event.entity, entity, event.world, chunk);
+			replaceEntity(event.entity, entity, event.world, event);
 			entity.getDataWatcher().updateObject(12, (byte) 1);
-			event.setCanceled(true);
 		}
 	}
 
-	private final Set<Chunk> loadedChunks = new HashSet<>();
-
-	@SubscribeEvent
-	public void chunkLoad(ChunkEvent.Load event) {
-		loadedChunks.add(event.getChunk());
-	}
-
-	@SubscribeEvent
-	public void chunkUnload(ChunkEvent.Unload event) {
-		loadedChunks.remove(event.getChunk());
-	}
-
-	private void replaceEntity(Entity oldEntity, Entity newEntity, World world, Chunk chunk) {
+	private void replaceEntity(Entity oldEntity, Entity newEntity, World world, Event event) {
 		newEntity.copyDataFrom(oldEntity, true);
-		if (loadedChunks.contains(chunk)) { // Use this list because somehow chunk.isChunkLoaded is always true here...
-			// World#addLoadedEntities has already run for the chunk, we don't have to worry about conflicting with it
-			world.spawnEntityInWorld(newEntity);
-		} else {
-			// don't add to tracker, because World#addLoadedEntities will also do it
-			chunk.addEntity(newEntity);
-		}
-		oldEntity.setDead();
+		world.spawnEntityInWorld(newEntity);
+		event.setCanceled(true);
 	}
 
 	@SubscribeEvent
@@ -1392,9 +1369,8 @@ public class ServerEventHandler {
 			BiomeDictionary.Type[] biomeTags = BiomeDictionary.getTypesForBiome(chunk.getBiomeGenForWorldCoords(x & 15, z & 15, world.getWorldChunkManager()));
 			if (ArrayUtils.contains(biomeTags, BiomeDictionary.Type.SNOWY)) {
 				EntityStray stray = new EntityStray(world);
-				replaceEntity(entity, stray, world, chunk);
+				replaceEntity(entity, stray, world, event);
 				stray.onSpawnWithEgg(null);
-				event.setCanceled(true);
 				event.setResult(Result.DENY);
 			}
 		} else if (ConfigEntities.enableHusk && !ConfigWorld.oldHuskSpawning && EntityList.getEntityID(entity) == 54 /*Zombie ID*/ && world.rand.nextFloat() < .80F && world.canBlockSeeTheSky(x, y + 1, z)) {
@@ -1402,9 +1378,8 @@ public class ServerEventHandler {
 			BiomeDictionary.Type[] biomeTags = BiomeDictionary.getTypesForBiome(chunk.getBiomeGenForWorldCoords(x & 15, z & 15, world.getWorldChunkManager()));
 			if (ArrayUtils.contains(biomeTags, BiomeDictionary.Type.HOT) && ArrayUtils.contains(biomeTags, BiomeDictionary.Type.DRY) && ArrayUtils.contains(biomeTags, BiomeDictionary.Type.SANDY)) {
 				EntityHusk husk = new EntityHusk(world);
-				replaceEntity(entity, husk, world, chunk);
+				replaceEntity(entity, husk, world, event);
 				husk.onSpawnWithEgg(null);
-				event.setCanceled(true);
 				event.setResult(Result.DENY);
 			}
 		}


### PR DESCRIPTION
it keeps a list of loaded chunks but i don't see why it's needed you can just spawn the entity in the world no problem