### PR TITLE
Allow & color codes on wood signs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.9.41:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.52:dev")
     compileOnly('curse.maven:rple-1050511:7358368') {transitive=false}
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive=false}
     compileOnly "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10:dev"

--- a/src/main/java/ganymedes01/etfuturum/client/gui/inventory/GuiEditWoodSign.java
+++ b/src/main/java/ganymedes01/etfuturum/client/gui/inventory/GuiEditWoodSign.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.gui.inventory;
 
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
 import ganymedes01.etfuturum.blocks.BlockWoodSign;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -97,7 +98,7 @@ public class GuiEditWoodSign extends GuiScreen {
 			this.tileSign.signText[this.editLine] = this.tileSign.signText[this.editLine].substring(0, this.tileSign.signText[this.editLine].length() - 1);
 		}
 
-		if (ChatAllowedCharacters.isAllowedCharacter(typedChar) && this.tileSign.signText[this.editLine].length() < 15) {
+		if (ChatAllowedCharacters.isAllowedCharacter(typedChar) && this.tileSign.signText[this.editLine].length() < 90 && FontRendering.countVisibleChars(this.tileSign.signText[this.editLine]) < 15) {
 			this.tileSign.signText[this.editLine] = this.tileSign.signText[this.editLine] + typedChar;
 		}
 

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/tileentity/TileEntityWoodSignRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/tileentity/TileEntityWoodSignRenderer.java
@@ -78,7 +78,7 @@ public class TileEntityWoodSignRenderer extends TileEntitySpecialRenderer {
 			String s = colour + sign.signText[i];
 
 			if (i == sign.lineBeingEdited) {
-				s = "> " + s + " <";
+				s = "> " + s + "§r <";
 				fontrenderer.drawString(s, -fontrenderer.getStringWidth(s) / 2, i * 10 - sign.signText.length * 5, b0);
 			} else {
 				fontrenderer.drawString(s, -fontrenderer.getStringWidth(s) / 2, i * 10 - sign.signText.length * 5, b0);


### PR DESCRIPTION
Use FontRendering.countVisibleChars to cap at 15 visible characters instead of 15 raw characters in GuiEditWoodSign, allowing & format codes (colors,gradients, effects) on EFR wood signs. Raw length capped at 90 to match Hodgepodge's server-side safety limit.
Requires Hodgepodge for server-side sign limit patches (packet read, validation, NBT read).

Bump GTNHLib from 0.9.41 to 0.9.52. (for the lib)