### PR TITLE
Fix concurency issue: Client and Server thread both mutating same collection

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -435,16 +435,19 @@ public class ServerEventHandler {
 
 	@SubscribeEvent
 	public void chunkLoad(ChunkEvent.Load event) {
+		if (event.world.isRemote) return;
 		getLongSet(event.world.provider.dimensionId).add(toLongCoords(event.getChunk()));
 	}
 
 	@SubscribeEvent
 	public void chunkUnload(ChunkEvent.Unload event) {
+		if (event.world.isRemote) return;
 		getLongSet(event.world.provider.dimensionId).remove(toLongCoords(event.getChunk()));
 	}
 
 	@SubscribeEvent
 	public void worldUnload(WorldEvent.Unload event) {
+		if (event.world.isRemote) return;
 		loadedChunks.remove(event.world.provider.dimensionId);
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25076

Fix Client and Server thread both mutating same LongOpenHashSet. Client shouldn't be touching that data.