### PR TITLE
Bump MCLib from 0.3.7.7 to 0.3.7.8

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,7 +63,7 @@ dependencies {
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {
         transitive = false
     }
-    shadowImplementation('com.github.makamys:MCLib:0.3.7.7') {
+    shadowImplementation('com.github.makamys:MCLib:0.3.7.8') {
         exclude group: "codechicken"
     }
 }


### PR DESCRIPTION
Fixes crash when asset cache is corrupt

* Bump to include https://github.com/makamys/MCLib/pull/7

* Resolves GTNewHorizons/GT-New-Horizons-Modpack#25114