### PR TITLE
Spectator mode: change fly speed by scrolling mouse wheel

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -105,6 +105,7 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 				mixins.add("spectator.client.MixinEntityRenderer");
 				mixins.add("spectator.client.MixinEntityPlayer");
 				mixins.add("spectator.client.MixinWorldRenderer");
+				mixins.add("spectator.client.MixinMinecraft");
 			}
 		}
 

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/client/MixinMinecraft.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/client/MixinMinecraft.java
@@ -1,0 +1,31 @@
+package ganymedes01.etfuturum.mixins.early.spectator.client;
+
+import ganymedes01.etfuturum.spectator.SpectatorMode;
+import ganymedes01.etfuturum.spectator.SpectatorModeClient;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.entity.player.InventoryPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft {
+
+	@Shadow
+	public EntityClientPlayerMP thePlayer;
+
+	@Redirect(
+			method = "runTick",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/entity/player/InventoryPlayer;changeCurrentItem(I)V"))
+	private void etfuturum$spectatorScrollFlySpeed(InventoryPlayer inventory, int delta) {
+		if (SpectatorMode.isSpectator(this.thePlayer)) {
+			SpectatorModeClient.INSTANCE.handleScrollFlySpeed(delta);
+		} else {
+			inventory.changeCurrentItem(delta);
+		}
+	}
+}

--- a/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
+++ b/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
@@ -169,14 +169,10 @@ public class SpectatorModeClient extends SpectatorMode {
 		if (player == null) {
 			return;
 		}
-		final float minSpeed = 0.1F; // default walkSpeed from PlayerCapabilities
 		float speed = player.capabilities.flySpeed + wheelDelta * 0.005F;
-		speed = Math.max(minSpeed, Math.min(0.2F, speed));
-		if (speed != player.capabilities.flySpeed) {
-			player.capabilities.flySpeed = speed;
-			player.sendPlayerAbilities();
-		}
-		int percent = Math.round((speed - minSpeed) / (0.2F - minSpeed) * 100.0F);
+		speed = Math.max(0.0F, Math.min(0.2F, speed));
+		player.capabilities.flySpeed = speed;
+		int percent = Math.round(speed / 0.2F * 100.0F);
 		Minecraft.getMinecraft().ingameGUI.func_110326_a/*setRecordPlaying*/(
 				net.minecraft.client.resources.I18n.format("etfuturum.spectator.flyspeed", percent), false);
 	}

--- a/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
+++ b/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
@@ -158,4 +158,26 @@ public class SpectatorModeClient extends SpectatorMode {
 			}
 		}
 	}
+
+	/**
+	 * Vanilla spectator behavior: scrolling the mouse wheel changes fly speed
+	 * instead of the hotbar slot. wheelDelta is the signum (-1 / +1) value that
+	 * runTick would otherwise pass to InventoryPlayer.changeCurrentItem.
+	 */
+	public void handleScrollFlySpeed(int wheelDelta) {
+		EntityClientPlayerMP player = FMLClientHandler.instance().getClientPlayerEntity();
+		if (player == null) {
+			return;
+		}
+		final float minSpeed = 0.1F; // default walkSpeed from PlayerCapabilities
+		float speed = player.capabilities.flySpeed + wheelDelta * 0.005F;
+		speed = Math.max(minSpeed, Math.min(0.2F, speed));
+		if (speed != player.capabilities.flySpeed) {
+			player.capabilities.flySpeed = speed;
+			player.sendPlayerAbilities();
+		}
+		int percent = Math.round((speed - minSpeed) / (0.2F - minSpeed) * 100.0F);
+		Minecraft.getMinecraft().ingameGUI.func_110326_a/*setRecordPlaying*/(
+				net.minecraft.client.resources.I18n.format("etfuturum.spectator.flyspeed", percent), false);
+	}
 }

--- a/src/main/resources/assets/etfuturum/lang/de_DE.lang
+++ b/src/main/resources/assets/etfuturum/lang/de_DE.lang
@@ -39,6 +39,7 @@ container.enchant.clue=%s . . . ?
 container.etfuturum.blast_furnace=Schmelzofen
 container.etfuturum.smoker=Räucherofen
 container.etfuturum.barrel=Fass
+etfuturum.spectator.flyspeed=Fluggeschwindigkeit: %s%%
 container.etfuturum.shulker_box=Shulker-Kiste
 container.etfuturum.chest_boat=Truhenboot
 

--- a/src/main/resources/assets/etfuturum/lang/en_US.lang
+++ b/src/main/resources/assets/etfuturum/lang/en_US.lang
@@ -1978,6 +1978,7 @@ tile.etfuturum.steel_barrel.name=Steel Barrel
 tile.etfuturum.darksteel_barrel.name=Dark Steel Barrel
 
 etfuturum.barrel.tooltip.slots=%d Slots
+etfuturum.spectator.flyspeed=Flying speed: %s%%
 
 
 tile.etfuturum.iron_shulker_box.name=Iron Shulker Box

--- a/src/main/resources/assets/etfuturum/lang/ru_RU.lang
+++ b/src/main/resources/assets/etfuturum/lang/ru_RU.lang
@@ -37,6 +37,7 @@ container.enchant.clue=%s . . . ?
 container.etfuturum.blast_furnace=Плавильная печь
 container.etfuturum.smoker=Коптильня
 container.etfuturum.barrel=Бочка
+etfuturum.spectator.flyspeed=Скорость полёта: %s%%
 container.etfuturum.shulker_box=Шалкеровый ящик
 container.etfuturum.chest_boat=Лодка с сундуком
 

--- a/src/main/resources/assets/etfuturum/lang/zh_CN.lang
+++ b/src/main/resources/assets/etfuturum/lang/zh_CN.lang
@@ -37,6 +37,7 @@ container.enchant.clue=%s…？
 container.etfuturum.blast_furnace=高炉
 container.etfuturum.smoker=烟熏炉
 container.etfuturum.barrel=木桶
+etfuturum.spectator.flyspeed=飞行速度：%s%%
 container.etfuturum.shulker_box=潜影盒
 container.etfuturum.chest_boat=运输船
 


### PR DESCRIPTION
In newer Java Edition, spectators scroll the mouse wheel to change fly speed instead of switching hotbar slots. This brings EFR spectator mode in line with that. Speed is clamped to vanilla's 0.0..0.2 range and shown as a percentage on screen; outside spectator mode the wheel still switches slots. Tested in-game.

https://i.imgur.com/1lqZqpL.gif