### PR TITLE
feat: backport ridden horse floating in liquids

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
@@ -50,6 +50,7 @@ public class ConfigMixins extends ConfigBase {
 	public static boolean modernLoadingScreen;
 	public static boolean adjustedLiquidPhysics;
 	public static boolean liquidItemFloat;
+	public static boolean riddenHorsesInWater;
 
 
 	static final String catBackport = "backported features";
@@ -119,6 +120,7 @@ public class ConfigMixins extends ConfigBase {
 				"\nModified Client Classes: net.minecraft.client.renderer.RenderBlocks");
 		adjustedLiquidPhysics = getBoolean("adjustedLiquidPhysics", catBackport, true, "Moves entities in lava, speeds up items in all liquids, floats items in liquids, changes some other liquid to entity interactions.\nModified Classes: net.minecraft.world.World net.minecraft.entity.Entity net.minecraft.block.BlockLiquid");
 		liquidItemFloat = getBoolean("liquidItemFloat", catBackport, true, "Floats items upwards in liquids.\nModified Classes: net.minecraft.entity.item.EntityItem");
+		riddenHorsesInWater = getBoolean("riddenHorsesInWater", catBackport, true, "Allows ridden horses to float in water like in modern Minecraft versions.");
 
 		stepHeightFix = getBoolean("stepHeightFix", catFixes, true, "Makes the player able to step up even if a block would be above their head at the destination.\nModified classes: net.minecraft.entity.Entity");
 		arrowFallingFix = getBoolean("arrowFallingFix", catFixes, true, "Prevents arrows from falling off of blocks too easily\nModified classes: net.minecraft.entity.EntityArrow");

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -264,6 +264,10 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 			mixins.add("liquidphysics.MixinEntityItem");
 		}
 
+		if (ConfigMixins.riddenHorsesInWater) {
+			mixins.add("horsewater.MixinEntityHorse");
+		}
+
 		if (false) { //Does not work for some reason, investigate in 2.6.1
 			mixins.add("darkspawns.MixinEntityMob");
 		}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/horsewater/MixinEntityHorse.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/horsewater/MixinEntityHorse.java
@@ -1,0 +1,27 @@
+package ganymedes01.etfuturum.mixins.early.horsewater;
+
+import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityHorse.class)
+public abstract class MixinEntityHorse extends EntityAnimal {
+
+	protected MixinEntityHorse(World world) {
+		super(world);
+	}
+
+	@Inject(method = "onLivingUpdate", at = @At("TAIL"))
+	private void floatWithRider(CallbackInfo ci) {
+		if (this.riddenByEntity == null
+				|| !this.worldObj.isAnyLiquid(this.boundingBox.contract(0.001D, 0.001D, 0.001D))) {
+			return;
+		}
+
+		this.motionY += 0.03D;
+	}
+}


### PR DESCRIPTION
## Summary
Backport ridden horses floating in liquids.
Makes early game more bearable since horses can now cross rivers with no issues.

https://github.com/user-attachments/assets/539cddba-324a-4a7a-b6a1-326821a288ca



## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
