### PR TITLE
Fix spectator equipment leaks visible to other players

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.11.22:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.28:dev")
     compileOnly('curse.maven:rple-1050511:7358368') {transitive=false}
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive=false}
     compileOnly "mcp.mobius.waila:Waila:1.5.11-RC2-NONEI_1.7.10:dev"
@@ -48,16 +48,18 @@ dependencies {
     compileOnly 'com.github.GTNewHorizons:ironchest:6.1.13'
     compileOnly 'curse.maven:applied-energistics-2-223794:2296430'
     compileOnly 'com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.8-backhand'
+    compileOnly("com.github.GTNewHorizons:Backhand:1.8.12:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.14-GTNH:dev") {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForbiddenMagic:0.9.16-GTNH:dev') {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.93-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:Angelica:2.1.49:api") {
+    compileOnly("com.github.GTNewHorizons:Angelica:2.1.53:api") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:lwjgl3ify:3.0.25:api") {
+    compileOnly("com.github.GTNewHorizons:lwjgl3ify:3.0.26:api") {
         transitive = false
     }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigFunctions.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigFunctions.java
@@ -161,6 +161,7 @@ public class ConfigFunctions extends ConfigBase {
 	public static boolean enableAttackedAtYawFix = true; //Servers should always send the packet, it's up to the client to disable handling of this feature
 	public static boolean enableSubtitles;
 	public static byte elytraDataWatcherFlag;
+	public static byte spectatorDataWatcherFlag;
 	public static boolean useStoneHardnessForDeepslate;
 	public static boolean enableDoorRecipeBuffs;
 	public static boolean inventoryBedModels;
@@ -224,6 +225,7 @@ public class ConfigFunctions extends ConfigBase {
 		registerRawItemAsOre = getBoolean("registerRawItemAsOre", catSettings, true, "Register the raw ore items in the OreDictionary as if they were the actual ore block. Such as raw iron being registered as an iron ore, etc...\nTurn this off if you have an ore dictionary converter mod or experience other issues.");
 		extraDropRawOres = getStringList("extraDropRawOres", catSettings, new String[]{"oreCopper", "oreTin"}, "OreDictionary values for ore blocks that should drop extra items (2-3) instead of the usual one, before fortune.");
 		elytraDataWatcherFlag = (byte) getInt("elytraDataWatcherFlag", catSettings, 7, 0, 31, "The data watcher flag for the Elytra, used to sync the elytra animation with other players. In vanilla the max value is 7, players use 0-4, so you can set this to 6 or 7 by default. ASJCore increases the max value to 31.\nDo not change this value if you don't need to, or do not know what you're doing.");
+		spectatorDataWatcherFlag = (byte) getInt("spectatorDataWatcherFlag", catSettings, 6, 0, 31, "The data watcher flag used to sync a player's spectator status to other players, so their equipment/accessories can be hidden from spectators. Must not collide with elytraDataWatcherFlag or any other mod's flag.\nDo not change this value if you don't need to, or do not know what you're doing.");
 		useStoneHardnessForDeepslate = getBoolean("useStoneHardnessForDeepslate", catSettings, false, "Whether deepslate blocks should have the same hardness as their stone counterparts. This allows the asthetics of deepslate without the added hardness.");
 
 		//client

--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ClientEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ClientEventHandler.java
@@ -118,7 +118,7 @@ import java.util.Random;
 import java.util.WeakHashMap;
 
 
-import static ganymedes01.etfuturum.spectator.SpectatorMode.isSpectator;
+import static ganymedes01.etfuturum.spectator.SpectatorMode.isSpectatorForRender;
 
 public class ClientEventHandler {
 
@@ -445,7 +445,7 @@ public class ClientEventHandler {
 			LayerBetterElytra.doRenderLayer(event.entityLiving, event.entityPlayer.limbSwing, event.entityPlayer.limbSwingAmount, Minecraft.getMinecraft().timer.renderPartialTicks, event.entityPlayer.getAge(), 0.0625F);
 		}
 
-		if (isSpectator(event.entityPlayer)) {
+		if (isSpectatorForRender(event.entityPlayer)) {
 			event.result = 0;
 		} else if (ConfigFunctions.enableTransparentAmour) {
 			OpenGLHelper.enableBlend();

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumLateMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumLateMixins.java
@@ -35,6 +35,12 @@ public class EtFuturumLateMixins implements ILateMixinLoader {
 			if (loadedMods.contains("Thaumcraft")) {
 				mixins.add("spectator.MixinItemHoverHarnessThaumcraft");
 			}
+			if (loadedMods.contains("backhand")) {
+				mixins.add("spectator.MixinClientEventHandlerBackhand");
+			}
+			if (loadedMods.contains("Backpack")) {
+				mixins.add("spectator.MixinEventHandlerClientOnlyBackpack");
+			}
 		}
 
 		return mixins;

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.mixins.early.spectator;
 
+import ganymedes01.etfuturum.configuration.configs.ConfigFunctions;
 import ganymedes01.etfuturum.spectator.SpectatorMode;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -72,6 +73,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
 
 	@Inject(method = "setGameType", at = @At("HEAD"))
 	private void dropCarriedItem(WorldSettings.GameType gameType, CallbackInfo ci) {
+		setFlag(ConfigFunctions.spectatorDataWatcherFlag, gameType == SpectatorMode.SPECTATOR_GAMETYPE);
 		if(gameType == SpectatorMode.SPECTATOR_GAMETYPE) {
 			ItemStack stack = inventory.getItemStack(); // Item in cursor
 			// Tries to add ItemStack to inventory, else drops it on the ground.

--- a/src/main/java/ganymedes01/etfuturum/mixins/late/spectator/MixinClientEventHandlerBackhand.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/late/spectator/MixinClientEventHandlerBackhand.java
@@ -6,12 +6,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import tconstruct.armor.ArmorProxyClient;
+import xonin.backhand.client.ClientEventHandler;
 
-@Mixin(value = ArmorProxyClient.class, remap = false)
-public class MixinArmorProxyClientTConstruct {
-	@Inject(method = "adjustArmor", at = @At("HEAD"), cancellable = true)
-	private void skipTConstructArmorExtrasForSpectator(RenderPlayerEvent.SetArmorModel event, CallbackInfo ci) {
+@Mixin(value = ClientEventHandler.class, remap = false)
+public class MixinClientEventHandlerBackhand {
+	@Inject(method = "render3rdPersonOffhand", at = @At("HEAD"), cancellable = true)
+	private static void skipOffhandItemForSpectator(RenderPlayerEvent.Specials.Post event, CallbackInfo ci) {
 		if (SpectatorMode.isSpectatorForRender(event.entityPlayer)) {
 			ci.cancel();
 		}

--- a/src/main/java/ganymedes01/etfuturum/mixins/late/spectator/MixinEventHandlerClientOnlyBackpack.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/late/spectator/MixinEventHandlerClientOnlyBackpack.java
@@ -1,17 +1,17 @@
 package ganymedes01.etfuturum.mixins.late.spectator;
 
+import de.eydamos.backpack.handler.EventHandlerClientOnly;
 import ganymedes01.etfuturum.spectator.SpectatorMode;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import tconstruct.armor.ArmorProxyClient;
 
-@Mixin(value = ArmorProxyClient.class, remap = false)
-public class MixinArmorProxyClientTConstruct {
-	@Inject(method = "adjustArmor", at = @At("HEAD"), cancellable = true)
-	private void skipTConstructArmorExtrasForSpectator(RenderPlayerEvent.SetArmorModel event, CallbackInfo ci) {
+@Mixin(value = EventHandlerClientOnly.class, remap = false)
+public class MixinEventHandlerClientOnlyBackpack {
+	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
+	private void skipBackpackForSpectator(RenderPlayerEvent.Specials.Pre event, CallbackInfo ci) {
 		if (SpectatorMode.isSpectatorForRender(event.entityPlayer)) {
 			ci.cancel();
 		}

--- a/src/main/java/ganymedes01/etfuturum/spectator/SpectatorMode.java
+++ b/src/main/java/ganymedes01/etfuturum/spectator/SpectatorMode.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.relauncher.Side;
 import ganymedes01.etfuturum.compat.ExternalContent;
+import ganymedes01.etfuturum.configuration.configs.ConfigFunctions;
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
 import ganymedes01.etfuturum.core.utils.helpers.SafeEnumHelperClient;
 import ganymedes01.etfuturum.entities.EntityNewBoatWithChest;
@@ -90,14 +91,17 @@ public class SpectatorMode {
 	 * {@link #isSpectator(EntityPlayer)} can only tell whether the *local* player is spectating:
 	 * the per-player GameType is not synced to other clients in 1.7.10, so it always returns false
 	 * for any other player's entity on the client. For rendering decisions about other players we
-	 * fall back to {@link EntityPlayer#isInvisible()}, which the server does set for spectators
-	 * (see {@link #onPlayerTick}) and which vanilla syncs to every client via the DataWatcher.
+	 * instead read a dedicated DataWatcher flag ({@link ConfigFunctions#spectatorDataWatcherFlag}),
+	 * set server-side whenever a player's GameType changes (see MixinEntityPlayer#dropCarriedItem)
+	 * and synced to every client by vanilla. Deliberately not reusing isInvisible(), since that flag
+	 * is also set by invisibility potions and would wrongly hide equipment on invisible non-spectators.
 	 */
 	public static boolean isSpectatorForRender(EntityPlayer player) {
-		if (isSpectator(player)) {
-			return true;
+		if (player == null) {
+			return false;
 		}
-		return player != null && player.worldObj != null && player.worldObj.isRemote && player.isInvisible();
+		byte flags = player.getDataWatcher().getWatchableObjectByte(0);
+		return (flags & (1 << ConfigFunctions.spectatorDataWatcherFlag)) != 0;
 	}
 
 	@SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/src/main/java/ganymedes01/etfuturum/spectator/SpectatorMode.java
+++ b/src/main/java/ganymedes01/etfuturum/spectator/SpectatorMode.java
@@ -86,6 +86,20 @@ public class SpectatorMode {
 		return player instanceof EntityPlayerMP && ((EntityPlayerMP) player).theItemInWorldManager.getGameType() == SPECTATOR_GAMETYPE;
 	}
 
+	/**
+	 * {@link #isSpectator(EntityPlayer)} can only tell whether the *local* player is spectating:
+	 * the per-player GameType is not synced to other clients in 1.7.10, so it always returns false
+	 * for any other player's entity on the client. For rendering decisions about other players we
+	 * fall back to {@link EntityPlayer#isInvisible()}, which the server does set for spectators
+	 * (see {@link #onPlayerTick}) and which vanilla syncs to every client via the DataWatcher.
+	 */
+	public static boolean isSpectatorForRender(EntityPlayer player) {
+		if (isSpectator(player)) {
+			return true;
+		}
+		return player != null && player.worldObj != null && player.worldObj.isRemote && player.isInvisible();
+	}
+
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onInteract(PlayerInteractEvent event) {
 		if (isSpectator(event.entityPlayer)) {

--- a/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
+++ b/src/main/java/ganymedes01/etfuturum/spectator/SpectatorModeClient.java
@@ -37,14 +37,14 @@ public class SpectatorModeClient extends SpectatorMode {
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onRenderPlayerPre(RenderPlayerEvent.Pre event) {
 		EntityPlayer viewer = Minecraft.getMinecraft().thePlayer;
-		if (viewer != null && isSpectator(event.entityPlayer) && event.entityPlayer != viewer
+		if (viewer != null && isSpectatorForRender(event.entityPlayer) && event.entityPlayer != viewer
 				&& !isSpectator(viewer) && !viewer.capabilities.isCreativeMode) {
 			event.setCanceled(true);
 			return;
 		}
 
 		if (!SPECTATING_ENTITIES.containsKey(event.entityPlayer)) {
-			if (isSpectator(event.entityPlayer)) {
+			if (isSpectatorForRender(event.entityPlayer)) {
 				setBipedVisible(event.renderer.modelBipedMain, false);
 				event.renderer.modelBipedMain.bipedHead.showModel = true;
 				event.renderer.modelBipedMain.bipedHeadwear.showModel = true;
@@ -58,7 +58,7 @@ public class SpectatorModeClient extends SpectatorMode {
 
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onRenderPlayerArmor(RenderPlayerEvent.Specials.Pre event) {
-		if (isSpectator(event.entityPlayer)) {
+		if (isSpectatorForRender(event.entityPlayer)) {
 			event.setCanceled(true);
 		}
 	}


### PR DESCRIPTION
isSpectator() could only determine spectator status for the local player on the client, since GameType isn't synced to other clients in 1.7.10, silently disabling every spectator-hiding render check for remote observers. Other players could still see armor, the Backhand offhand item, the Backpack model and TConstruct accessories on a spectating player.