### PR TITLE
Finish Dripstone

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -48,6 +48,7 @@ dependencies {
     compileOnly 'com.github.GTNewHorizons:ironchest:6.1.13'
     compileOnly 'curse.maven:applied-energistics-2-223794:2296430'
     compileOnly 'com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.8-backhand'
+    compileOnly 'org.jetbrains:annotations:26.0.1'
     compileOnly('com.github.GTNewHorizons:ForbiddenMagic:0.9.16-GTNH:dev') {
         transitive = false
     }

--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -27,6 +27,7 @@ import ganymedes01.etfuturum.api.CompostingRegistry;
 import ganymedes01.etfuturum.api.DeepslateOreRegistry;
 import ganymedes01.etfuturum.api.HoeRegistry;
 import ganymedes01.etfuturum.api.MultiBlockSoundRegistry;
+import ganymedes01.etfuturum.api.DripOperationRegistry;
 import ganymedes01.etfuturum.api.PistonBehaviorRegistry;
 import ganymedes01.etfuturum.api.RawOreRegistry;
 import ganymedes01.etfuturum.api.StrippedLogRegistry;
@@ -442,6 +443,7 @@ public class EtFuturum {
 		CompostingRegistry.init();
 		BeePlantRegistry.init();
 		PistonBehaviorRegistry.init();
+		DripOperationRegistry.init();
 
 		if (ModsList.TINKERS_CONSTRUCT.isLoaded()) {
 			CompatTinkersConstruct.postInit();

--- a/src/main/java/ganymedes01/etfuturum/ModBlocks.java
+++ b/src/main/java/ganymedes01/etfuturum/ModBlocks.java
@@ -491,9 +491,9 @@ public enum ModBlocks {
 	FLETCHING_TABLE(ConfigBlocksItems.enableFletchingTable, new BlockFletchingTable(), ItemBlockDecorationWorkbench.class),
 	CARTOGRAPHY_TABLE(ConfigBlocksItems.enableCartographyTable, new BlockCartographyTable(), ItemBlockDecorationWorkbench.class),
 	LOOM(ConfigBlocksItems.enableLoom, new BlockLoom(), ItemBlockDecorationWorkbench.class),
-	DRIPSTONE_BLOCK(ConfigExperiments.enableDripstone, new BaseBlock(Material.rock).setNames("dripstone_block")
+	DRIPSTONE_BLOCK(ConfigBlocksItems.enableDripstone, new BaseBlock(Material.rock).setNames("dripstone_block")
 			.setBlockSound(ModSounds.soundDripstoneBlock).setHardness(1.5F).setResistance(1F)),
-	POINTED_DRIPSTONE(ConfigExperiments.enableDripstone, new BlockPointedDripstone()),
+	POINTED_DRIPSTONE(ConfigBlocksItems.enableDripstone, new BlockPointedDripstone()),
 	HONEY_BLOCK(ConfigBlocksItems.enableHoney, new BlockHoney()),
 	HONEYCOMB_BLOCK(ConfigBlocksItems.enableHoney, new BaseBlock(Material.clay).setNames("honeycomb_block")
 			.setBlockSound(ModSounds.soundCoralBlock).setHardness(0.6F).setResistance(0.6F)),

--- a/src/main/java/ganymedes01/etfuturum/api/DripOperationRegistry.java
+++ b/src/main/java/ganymedes01/etfuturum/api/DripOperationRegistry.java
@@ -1,0 +1,94 @@
+package ganymedes01.etfuturum.api;
+
+import com.google.common.collect.Lists;
+import ganymedes01.etfuturum.ModBlocks;
+import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
+import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DripOperationRegistry {
+
+    private static final List<IDripOperation> OPERATIONS = Lists.newArrayList();
+
+    /** Registers a custom drip operation. Operations run in registration order. */
+    public static void register(@NotNull IDripOperation operation) {
+        OPERATIONS.add(operation);
+    }
+
+    /**
+     * Iterates registered operations and stops at the first that returns true.
+     *
+     * Assumption: called server-side only, from BlockPointedDripstone.updateTick.
+     */
+    @ApiStatus.Internal
+    public static void runOperations(World world,
+                                     int tipX, int tipY, int tipZ,
+                                     int targetX, int targetY, int targetZ,
+                                     @NotNull Fluid fluid) {
+        for (IDripOperation op : OPERATIONS) {
+            if (op.apply(world, tipX, tipY, tipZ, targetX, targetY, targetZ, fluid)) {
+                return;
+            }
+        }
+    }
+
+    /** Registers the built-in drip operations. Called from {@code EtFuturum.postInit}. */
+    public static void init() {
+        if (!ConfigExperiments.enableDripstone) return;
+
+        if (ConfigBlocksItems.enableLavaCauldrons) {
+            register(new LavaCauldronFillOperation());
+        }
+
+        register(new WaterCauldronFillOperation());
+    }
+
+    // Built-in operations — registered in init(), available for reference/extension
+
+    /** Fills an empty water cauldron one level when water drips. 45/256 chance. */
+    static final class WaterCauldronFillOperation implements IDripOperation {
+
+        @Override
+        public boolean apply(World world,
+                             int tipX, int tipY, int tipZ,
+                             int targetX, int targetY, int targetZ,
+                             @NotNull Fluid fluid) {
+            if (fluid != FluidRegistry.WATER) return false;
+            if (world.getBlock(targetX, targetY, targetZ) != Blocks.cauldron) return false;
+
+            int meta = world.getBlockMetadata(targetX, targetY, targetZ);
+            if (meta >= 3) return false;
+
+            if (world.rand.nextInt(256) >= 45) return false;
+
+            world.setBlockMetadataWithNotify(targetX, targetY, targetZ, meta + 1, 3);
+            return true;
+        }
+    }
+
+    /** Fills an empty cauldron with lava when lava drips. 15/256 chance. */
+    static final class LavaCauldronFillOperation implements IDripOperation {
+
+        @Override
+        public boolean apply(World world,
+                             int tipX, int tipY, int tipZ,
+                             int targetX, int targetY, int targetZ,
+                             @NotNull Fluid fluid) {
+            if (fluid != FluidRegistry.LAVA) return false;
+            if (world.getBlock(targetX, targetY, targetZ) != Blocks.cauldron) return false;
+            if (world.getBlockMetadata(targetX, targetY, targetZ) != 0) return false;
+
+            if (world.rand.nextInt(256) >= 15) return false;
+
+            world.setBlock(targetX, targetY, targetZ, ModBlocks.LAVA_CAULDRON.get(), 3, 3);
+            return true;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/api/DripOperationRegistry.java
+++ b/src/main/java/ganymedes01/etfuturum/api/DripOperationRegistry.java
@@ -3,7 +3,7 @@ package ganymedes01.etfuturum.api;
 import com.google.common.collect.Lists;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
-import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
@@ -41,7 +41,7 @@ public class DripOperationRegistry {
 
     /** Registers the built-in drip operations. Called from {@code EtFuturum.postInit}. */
     public static void init() {
-        if (!ConfigExperiments.enableDripstone) return;
+        if (!ConfigBlocksItems.enableDripstone) return;
 
         if (ConfigBlocksItems.enableLavaCauldrons) {
             register(new LavaCauldronFillOperation());

--- a/src/main/java/ganymedes01/etfuturum/api/IDripOperation.java
+++ b/src/main/java/ganymedes01/etfuturum/api/IDripOperation.java
@@ -1,0 +1,31 @@
+package ganymedes01.etfuturum.api;
+
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Server-side action triggered when a stalactite drips toward a target block.
+ * Register implementations via {@link DripOperationRegistry#register}.
+ *
+ * <p>Operations run in registration order. The first to return {@code true}
+ * consumes the event and skips remaining operations for that tick.
+ */
+public interface IDripOperation {
+
+    /**
+     * @param world   the server world (never remote)
+     * @param tipX    X of the stalactite tip block
+     * @param tipY    Y of the stalactite tip block
+     * @param tipZ    Z of the stalactite tip block
+     * @param targetX X of the target block below the stalactite
+     * @param targetY Y of the target block below the stalactite
+     * @param targetZ Z of the target block below the stalactite
+     * @param fluid   the source fluid above the stalactite base
+     * @return {@code true} to consume the event and skip remaining operations
+     */
+    boolean apply(World world,
+                  int tipX, int tipY, int tipZ,
+                  int targetX, int targetY, int targetZ,
+                  @NotNull Fluid fluid);
+}

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockLavaCauldron.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockLavaCauldron.java
@@ -28,19 +28,6 @@ public class BlockLavaCauldron extends BlockCauldron {
 	}
 
 	@Override
-	public boolean onBlockActivated(World worldIn, int x, int y, int z, EntityPlayer player, int side, float subX, float subY, float subZ) {
-//      ItemStack item;
-//      if (player.getCurrentEquippedItem() != null) {
-//          item = player.getCurrentEquippedItem();
-//          if (item.getItem() instanceof ItemBucket) {
-//              // TODO Bucketing lava out of the cauldron
-//          }
-//      }
-//      return true;
-		return super.onBlockActivated(worldIn, x, y, z, player, side, subX, subY, subZ);
-	}
-
-	@Override
 	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
 		if (!world.isRemote && !entity.isImmuneToFire()) {
 			if (!(entity instanceof EntityLiving) && !entity.isBurning()) {

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -28,7 +28,9 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.IIcon;
@@ -110,6 +112,7 @@ public class BlockPointedDripstone extends Block {
 	}
 
 	public static final DamageSource STALACTITE_DAMAGE = new DamageSource("stalactite");
+	public static final DamageSource STALAGMITE_DAMAGE = new DamageSource("stalagmite");
 
 	public BlockPointedDripstone() {
 		super(Material.rock);
@@ -292,6 +295,27 @@ public class BlockPointedDripstone extends Block {
 	) {
 		this.setBlockBoundsBasedOnState(worldIn, x, y, z);
 		super.addCollisionBoxesToList(worldIn, x, y, z, mask, list, collider);
+	}
+
+	@Override
+	public void onFallenUpon(World world, int x, int y, int z, Entity entity, float fallDistance) {
+		if (!up.getBooleanValue(world, x, y, z)) {
+			super.onFallenUpon(world, x, y, z, entity, fallDistance);
+			return;
+		}
+		DripstoneState s = state.getValue(world, x, y, z);
+		if (s != DripstoneState.Tip && s != DripstoneState.TipMerge) {
+			super.onFallenUpon(world, x, y, z, entity, fallDistance);
+			return;
+		}
+		// Stalagmite tip: replaces normal fall damage — do not call super
+		entity.fallDistance = 0.0F;
+		if (entity.isEntityInvulnerable()) return;
+		if (entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.allowFlying) return;
+		int damage = MathHelper.ceiling_float_int(fallDistance * 2.0F - 2.0F);
+		if (damage > 0) {
+			entity.attackEntityFrom(STALAGMITE_DAMAGE, damage);
+		}
 	}
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -486,28 +486,123 @@ public class BlockPointedDripstone extends Block {
 		return -1;
 	}
 
+	/**
+	 * Scans downward from just below the stalactite tip to find a stalagmite (up=true) Tip,
+	 * or a solid surface where a new stalagmite tip can start.
+	 * Returns the Y coordinate of the existing stalagmite tip or the empty slot above a solid surface,
+	 * or -1 if the path is blocked or nothing suitable is found.
+	 */
+	private int findStalagmiteTipY(World world, int x, int tipY, int z) {
+		for (int y = tipY - 1; y >= tipY - 10; y--) {
+			Block b = world.getBlock(x, y, z);
+
+			if (b == this && up.getBooleanValue(world, x, y, z)) {
+				DripstoneState s = state.getValue(world, x, y, z);
+				return s == DripstoneState.Tip || s == DripstoneState.TipMerge ? y : -1;
+			}
+
+			if (!isPassable(world, x, y, z, b)) {
+				// Solid block: y+1 is the slot for a new stalagmite tip
+				if (world.isSideSolid(x, y, z, ForgeDirection.UP) && world.isAirBlock(x, y + 1, z)) {
+					return y + 1;
+				}
+				return -1;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Places a new Tip block one step in the growth direction and updates the surrounding states.
+	 * Assumption: the target block at growY must be air before calling this.
+	 */
+	private void growTip(World world, int x, int tipY, int z, boolean pointingUp) {
+		int growY = tipY + (pointingUp ? 1 : -1);
+
+		world.setBlock(x, growY, z, this, up.getMetaPrimitive(pointingUp, 0), 2);
+
+		updateState(world, x, growY, z);
+		updateState(world, x, tipY, z);
+	}
+
+	/**
+	 * Attempts to grow the stalactite tip downward or a stalagmite tip upward.
+	 * Fires from the TIP block's random tick. Requires a dripstone_block above the base,
+	 * a water source 2 above the base, max length 8, and a 64/5625 chance (~1.138%).
+	 */
+	private void tryGrow(World world, int x, int tipY, int z, Random rand) {
+		int topOffset = findStalactiteTopOffset(world, x, tipY, z);
+		int baseY = tipY + topOffset;
+		int length = topOffset + 1;
+
+		// Must hang from dripstone_block
+		if (world.getBlock(x, baseY + 1, z) != ModBlocks.DRIPSTONE_BLOCK.get()) return;
+
+		// Water only — lava does not grow dripstone
+		Fluid fluid = fluidSourceAt(world, x, baseY + 2, z);
+		if (fluid != FluidRegistry.WATER) return;
+
+		// Max stalactite length 8 (wiki: "does not occur if 8 or more blocks long")
+		if (length >= 8) return;
+
+		// 64/5625 ≈ 1.138% chance (vanilla growth rate)
+		if (rand.nextInt(5625) >= 64) return;
+
+		// Stalactite growth: extend tip downward if air below
+		if (world.isAirBlock(x, tipY - 1, z)) {
+			growTip(world, x, tipY, z, false);
+			return;
+		}
+
+		// Stalactite tip is blocked; try growing the stalagmite instead
+		int targetY = findStalagmiteTipY(world, x, tipY, z);
+		if (targetY < 0) return;
+
+		Block targetBlock = world.getBlock(x, targetY, z);
+		if (targetBlock == this) {
+			// Existing stalagmite tip: grow upward if space above
+			if (world.isAirBlock(x, targetY + 1, z)) {
+				growTip(world, x, targetY, z, true);
+			}
+		} else {
+			// targetY is a solid-surface slot — place new stalagmite tip there
+			world.setBlock(x, targetY, z, this, up.getMetaPrimitive(true, 0), 2);
+			updateState(world, x, targetY, z);
+		}
+	}
+
 	@Override
 	public void updateTick(World world, int x, int y, int z, Random rand) {
 		if (world.isRemote) return;
 		if (up.getBooleanValue(world, x, y, z)) return;
-		if (countDripstone(world, x, y, z, false, true, false) > 1) return;
 
-		// Mud→clay: the mud sits above the solid support block (y+1), so at y+2.
-		// Not affected by length restriction and runs independently of fluid presence.
+		DripstoneState currentState = state.getValue(world, x, y, z);
+		boolean isTopmost = countDripstone(world, x, y, z, false, true, false) <= 1;
+
+		// Growth: fires from TIP block only
+		if (currentState == DripstoneState.Tip) {
+			tryGrow(world, x, y, z, rand);
+		}
+
+		// Mud→clay and cauldron fill: fires from BASE (topmost) block only
+		if (!isTopmost) return;
+
+		// Mud→clay: mud sits at y+2 (above the solid support at y+1).
 		if (!world.provider.isHellWorld && ModBlocks.MUD.isEnabled()) {
 			if (world.getBlock(x, y + 2, z) == ModBlocks.MUD.get() && rand.nextInt(256) < 45) {
 				world.setBlock(x, y + 2, z, Blocks.clay, 0, 3);
 			}
 		}
 
-		if (stalactiteLength(world, x, y, z) > 10) return;
-
-		// The fluid source must be 2 blocks above the base (1 block above the solid support).
+		// Fluid source must be 2 blocks above the base (1 above solid support).
 		Fluid fluid = fluidSourceAt(world, x, y + 2, z);
 		if (fluid == null) return;
 
 		int tipY = findStalactiteTipY(world, x, y, z);
 		if (tipY < 0) return;
+
+		if (stalactiteLength(world, x, y, z) > 10) return;
 
 		int cauldronY = findCauldronY(world, x, tipY, z);
 		if (cauldronY < 0) return;
@@ -556,6 +651,8 @@ public class BlockPointedDripstone extends Block {
 		} else {
 			color = fluid.getColor(world, x, y + topOffset + 2, z);
 		}
+
+		setBlockBoundsBasedOnState(world, x, y, z);
 
 		double px = x + minX + (maxX - minX) * 0.5;
 		double pz = z + minZ + (maxZ - minZ) * 0.5;

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -557,8 +557,6 @@ public class BlockPointedDripstone extends Block {
 			color = fluid.getColor(world, x, y + topOffset + 2, z);
 		}
 
-		setBlockBoundsBasedOnState(world, x, y, z);
-
 		double px = x + minX + (maxX - minX) * 0.5;
 		double pz = z + minZ + (maxZ - minZ) * 0.5;
 

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -1,21 +1,33 @@
 package ganymedes01.etfuturum.blocks;
 
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Random;
 
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockPropertyTrait;
+import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
+import com.gtnewhorizon.gtnhlib.blockstate.core.BlockStatePool;
 import com.gtnewhorizon.gtnhlib.blockstate.core.MetaBlockProperty;
 import com.gtnewhorizon.gtnhlib.blockstate.properties.BooleanBlockProperty.BooleanMetaBlockProperty;
 import com.gtnewhorizon.gtnhlib.blockstate.registry.BlockPropertyRegistry;
+import com.gtnewhorizon.gtnhlib.color.RGBColor;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.EtFuturum;
+import ganymedes01.etfuturum.ModBlocks;
+import ganymedes01.etfuturum.api.DripOperationRegistry;
+import ganymedes01.etfuturum.client.particle.CustomParticles;
 import ganymedes01.etfuturum.client.sound.ModSounds;
 import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.entities.EntityFallingDripstone;
 import ganymedes01.etfuturum.lib.RenderIDs;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockCauldron;
+import net.minecraft.block.BlockTrapDoor;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.DamageSource;
@@ -23,6 +35,9 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import org.jetbrains.annotations.Nullable;
 
 public class BlockPointedDripstone extends Block {
 
@@ -105,6 +120,7 @@ public class BlockPointedDripstone extends Block {
 		this.setBlockName(Utils.getUnlocalisedName("pointed_dripstone"));
 		this.setBlockTextureName("pointed_dripstone");
 		this.setCreativeTab(EtFuturum.creativeTabBlocks);
+		this.setTickRandomly(true);
 
 		BlockPropertyRegistry.registerProperty(this, up);
 		BlockPropertyRegistry.registerProperty(this, state);
@@ -270,19 +286,38 @@ public class BlockPointedDripstone extends Block {
 	}
 
 	@Override
+	public void addCollisionBoxesToList(
+		World worldIn, int x, int y, int z, AxisAlignedBB mask,
+		List<AxisAlignedBB> list, Entity collider
+	) {
+		this.setBlockBoundsBasedOnState(worldIn, x, y, z);
+		super.addCollisionBoxesToList(worldIn, x, y, z, mask, list, collider);
+	}
+
+	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
 		DripstoneState state = this.state.getValue(world, x, y, z);
 
 		int shrinkage = switch (state) {
-            case Base -> 0;
-            case Middle -> 1;
-            case Frustum -> 2;
-            case Tip, TipMerge -> 3;
-        };
+			case Base -> 0;
+			case Middle -> 1;
+			case Frustum -> 2;
+			case Tip, TipMerge -> 3;
+		};
 
-		float offset = 0.125F + (float) shrinkage * 0.0625F;
+		float pixel = 0.0625f;
+		float offset = (float) (shrinkage + 2) * pixel;
 
-		return AxisAlignedBB.getBoundingBox(x + offset, y, z + offset, x + (1 - offset), y + 1.0F, z + (1 - offset));
+		if (state == DripstoneState.Tip) {
+			boolean pointingUp = this.up.getBooleanValue(world, x, y, z);
+
+			return AxisAlignedBB.getBoundingBox(
+				x + offset, y + (pointingUp ? 0F : pixel * 5), z + offset,
+				x + (1 - offset), y + (pointingUp ? pixel * 11 : 1.0F), z + (1 - offset)
+			);
+		} else {
+			return AxisAlignedBB.getBoundingBox(x + offset, y, z + offset, x + (1 - offset), y + 1.0F, z + (1 - offset));
+		}
 	}
 
 	@Override
@@ -296,9 +331,17 @@ public class BlockPointedDripstone extends Block {
 			case Tip, TipMerge -> 3;
 		};
 
-		float offset = 0.125F + (float) shrinkage * 0.0625F;
+		float pixel = 0.0625f;
 
-		this.setBlockBounds(offset, 0, offset, 1 - offset, 1.0F, 1 - offset);
+		float offset = (float) (shrinkage + 2) * pixel;
+
+		if (state == DripstoneState.Tip) {
+			boolean pointingUp = this.up.getBooleanValue(access, x, y, z);
+
+			this.setBlockBounds(offset, pointingUp ? 0F : pixel * 5, offset, 1 - offset, pointingUp ? pixel * 11 : 1.0F, 1 - offset);
+		} else {
+			this.setBlockBounds(offset, 0, offset, 1 - offset, 1.0F, 1 - offset);
+		}
 	}
 
 	@Override
@@ -340,4 +383,185 @@ public class BlockPointedDripstone extends Block {
 		return "pointed_dripstone";
 	}
 
+	/**
+	 * Returns the number of contiguous down-pointing dripstone blocks starting from
+	 * the base and scanning downward. Returns at most 12 to bound the search.
+	 */
+	private int stalactiteLength(World world, int x, int baseY, int z) {
+		int count = 0;
+		int scanY = baseY;
+
+		while (count <= 11) {
+			if (world.getBlock(x, scanY, z) != this) break;
+			if (up.getBooleanValue(world, x, scanY, z)) break;
+			count++;
+			scanY--;
+		}
+
+		return count;
+	}
+
+	/**
+	 * Scans downward from the base to find the Y coordinate of the tip.
+	 * Returns -1 if no tip is found within 11 blocks or if a non-stalactite block is encountered.
+	 */
+	private int findStalactiteTipY(World world, int x, int baseY, int z) {
+		int scanY = baseY;
+
+		for (int i = 0; i <= 11; i++) {
+			if (world.getBlock(x, scanY, z) != this) return -1;
+			if (up.getBooleanValue(world, x, scanY, z)) return -1;
+
+			DripstoneState s = state.getValue(world, x, scanY, z);
+			if (s == DripstoneState.Tip || s == DripstoneState.TipMerge) return scanY;
+
+			scanY--;
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Scans upward from the tip to find the Y coordinate of the base.
+	 * Returns -1 if no base is found within 11 blocks or if a non-stalactite block is encountered.
+	 */
+	private int findStalactiteTopOffset(World world, int x, int tipY, int z) {
+		int scanY = tipY;
+
+		int i;
+
+		for (i = 0; i <= 11; i++) {
+			if (world.getBlock(x, scanY, z) != this) break;
+			if (up.getBooleanValue(world, x, scanY, z)) break;
+
+			scanY++;
+		}
+
+		return i - 1;
+	}
+
+	/**
+	 * Returns the Forge {@link Fluid} at the given position if it is a fluid source block
+	 * (meta == 0), or {@code null} if the block is not a fluid or is a flowing fluid.
+	 */
+	@Nullable
+	private Fluid fluidSourceAt(World world, int x, int y, int z) {
+		Block block = world.getBlock(x, y, z);
+		if (block.getMaterial() != Material.water && block.getMaterial() != Material.lava) return null;
+		if (world.getBlockMetadata(x, y, z) != 0) return null;
+
+		return FluidRegistry.lookupFluidForBlock(block);
+	}
+
+	private final BlockStatePool pool = new BlockStatePool(4);
+
+	/**
+	 * Returns true if a block allows drip to pass through it.
+	 * Covers air, ladders, open trapdoors, signs, torches, and any block with no collision box.
+	 */
+	private boolean isPassable(World world, int x, int y, int z, Block block) {
+		if (block instanceof BlockTrapDoor) {
+			try (BlockState state = BlockPropertyRegistry.getBlockState(pool, world, x, y, z)) {
+				return state.getPropertyValue("open");
+			}
+		}
+
+		return block.getCollisionBoundingBoxFromPool(world, x, y, z) == null;
+	}
+
+	/**
+	 * Scans downward from just below the tip to find a cauldron within 10 blocks.
+	 * Stops early if a non-passable, non-target block is encountered.
+	 * Returns the Y coordinate of the cauldron, or -1 if none is reachable.
+	 */
+	private int findCauldronY(World world, int x, int tipY, int z) {
+		for (int y = tipY - 1; y >= tipY - 10; y--) {
+			Block b = world.getBlock(x, y, z);
+
+			if (b instanceof BlockCauldron || b instanceof BlockCauldronTileEntity) return y;
+
+			if (!isPassable(world, x, y, z, b)) return -1;
+		}
+
+		return -1;
+	}
+
+	@Override
+	public void updateTick(World world, int x, int y, int z, Random rand) {
+		if (world.isRemote) return;
+		if (up.getBooleanValue(world, x, y, z)) return;
+		if (countDripstone(world, x, y, z, false, true, false) > 1) return;
+
+		// Mud→clay: the mud sits above the solid support block (y+1), so at y+2.
+		// Not affected by length restriction and runs independently of fluid presence.
+		if (!world.provider.isHellWorld && ModBlocks.MUD.isEnabled()) {
+			if (world.getBlock(x, y + 2, z) == ModBlocks.MUD.get() && rand.nextInt(256) < 45) {
+				world.setBlock(x, y + 2, z, Blocks.clay, 0, 3);
+			}
+		}
+
+		if (stalactiteLength(world, x, y, z) > 10) return;
+
+		// The fluid source must be 2 blocks above the base (1 block above the solid support).
+		Fluid fluid = fluidSourceAt(world, x, y + 2, z);
+		if (fluid == null) return;
+
+		int tipY = findStalactiteTipY(world, x, y, z);
+		if (tipY < 0) return;
+
+		int cauldronY = findCauldronY(world, x, tipY, z);
+		if (cauldronY < 0) return;
+
+		DripOperationRegistry.runOperations(world, x, tipY, z, x, cauldronY, z, fluid);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
+		if (rand.nextInt(40) != 0) return;
+
+		if (up.getBooleanValue(world, x, y, z)) return;
+
+		DripstoneState currentState = state.getValue(world, x, y, z);
+		if (currentState != DripstoneState.Tip && currentState != DripstoneState.TipMerge) return;
+
+		// TipMerge is the analog of a waterlogged tip — no drip particles
+		if (currentState == DripstoneState.TipMerge) return;
+
+		int topOffset = findStalactiteTopOffset(world, x, y, z);
+		if (topOffset < 0 || topOffset >= 11) return;
+
+		// The fluid source must be 2 blocks above the base (1 block above the solid support).
+		Fluid fluid = fluidSourceAt(world, x, y + topOffset + 2, z);
+		if (fluid == null) {
+			// Fluid-less = 3x slower drips
+			if (rand.nextInt(3) != 0) return;
+
+			fluid = world.provider.isHellWorld ? FluidRegistry.LAVA : FluidRegistry.WATER;
+		}
+
+		int color;
+
+		if (fluid == FluidRegistry.WATER) {
+			RGBColor mult = RGBColor.fromRGB(Blocks.water.colorMultiplier(world, x, y + topOffset + 2, z));
+			RGBColor base = RGBColor.fromRGB(MapColor.waterColor.colorValue);
+
+			base.red = base.red * mult.red / 255;
+			base.green = base.green * mult.green / 255;
+			base.blue = base.blue * mult.blue / 255;
+
+			color = base.toIntRGB();
+		} else if (fluid == FluidRegistry.LAVA) {
+			color = 0xff7813;
+		} else {
+			color = fluid.getColor(world, x, y + topOffset + 2, z);
+		}
+
+		setBlockBoundsBasedOnState(world, x, y, z);
+
+		double px = x + minX + (maxX - minX) * 0.5;
+		double pz = z + minZ + (maxZ - minZ) * 0.5;
+
+		CustomParticles.spawnDrippingParticle(world, px, y + minY - 0.05f, pz, color | 0xFF000000);
+	}
 }

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -169,33 +169,33 @@ public class BlockPointedDripstone extends Block {
 		return count;
 	}
 
-	@Override
-	public int onBlockPlaced(World world, int x, int y, int z, int side, float subX, float subY, float subZ, int meta) {
-		ForgeDirection dir = ForgeDirection.getOrientation(side);
-
-		boolean pointingUp = dir == ForgeDirection.UP;
-
-		int count = countDripstone(world, x, y, z, pointingUp, pointingUp, true);
-
-		DripstoneState state = switch (count) {
+	/// Computes the dripstone state for a block at (x,y,z). `skipFirst` should be true when placing.
+	private DripstoneState computeState(World world, int x, int y, int z, boolean pointingUp, boolean skipFirst) {
+		int count = countDripstone(world, x, y, z, pointingUp, pointingUp, skipFirst);
+		DripstoneState result = switch (count) {
 			case 1 -> DripstoneState.Tip;
 			case 2 -> DripstoneState.Frustum;
 			default -> DripstoneState.Middle;
 		};
 
-		if (state == DripstoneState.Middle && countDripstone(world, x, y, z, pointingUp, !pointingUp, true) == 1) {
-			state = DripstoneState.Base;
+		if (result == DripstoneState.Middle && countDripstone(world, x, y, z, pointingUp, !pointingUp, skipFirst) == 1) {
+			result = DripstoneState.Base;
 		}
 
-		int dy = pointingUp ? 1 : -1;
-
-		if (state == DripstoneState.Tip && countDripstone(world, x, y + dy, z, !pointingUp, pointingUp, false) > 0) {
-			state = DripstoneState.TipMerge;
+		int stepY = pointingUp ? 1 : -1;
+		if (result == DripstoneState.Tip && countDripstone(world, x, y + stepY, z, !pointingUp, pointingUp, false) > 0) {
+			result = DripstoneState.TipMerge;
 		}
 
+		return result;
+	}
+
+	@Override
+	public int onBlockPlaced(World world, int x, int y, int z, int side, float subX, float subY, float subZ, int meta) {
+		boolean pointingUp = ForgeDirection.getOrientation(side) == ForgeDirection.UP;
+		DripstoneState state = computeState(world, x, y, z, pointingUp, true);
 		meta = this.up.getMetaPrimitive(pointingUp, 0);
 		meta = this.state.getMeta(state, meta);
-
 		return meta;
 	}
 
@@ -233,24 +233,22 @@ public class BlockPointedDripstone extends Block {
 		}
 	}
 
-	/**
-	 * Clears the whole contiguous run of down-pointing dripstone hanging below (x,y,z) in one
-	 * synchronous pass and spawns a single falling entity for it, rather than one entity per block.
-	 * Doing this atomically (instead of relying on onNeighborBlockChange to cascade block-by-block
-	 * across ticks) avoids a race where a redundant notification for a still-standing block spawns a
-	 * competing entity before the first one gets a chance to remove it.
-	 */
+	/// Clears the whole contiguous run of down-pointing dripstone hanging below (x,y,z) in one
+	/// synchronous pass and spawns a single falling entity for it, rather than one entity per block.
+	/// Doing this atomically (instead of relying on onNeighborBlockChange to cascade block-by-block
+	/// across ticks) avoids a race where a redundant notification for a still-standing block spawns a
+	/// competing entity before the first one gets a chance to remove it.
 	private void collapseHangingColumn(World world, int x, int y, int z) {
 		int meta = world.getBlockMetadata(x, y, z);
 
 		int count = 0;
-		int y2 = y;
+		int scanY = y;
 
 		this.collapsing = true;
 
-		while (!up.getBooleanValue(world, x, y2, z) && world.getBlock(x, y2, z) == this) {
-			world.setBlock(x, y2, z, Blocks.air, 0, 2);
-			y2--;
+		while (!up.getBooleanValue(world, x, scanY, z) && world.getBlock(x, scanY, z) == this) {
+			world.setBlock(x, scanY, z, Blocks.air, 0, 2);
+			scanY--;
 			count++;
 		}
 
@@ -263,28 +261,9 @@ public class BlockPointedDripstone extends Block {
 
 	private void updateState(World world, int x, int y, int z) {
 		boolean pointingUp = up.getBooleanValue(world, x, y, z);
-
-		int count = countDripstone(world, x, y, z, pointingUp, pointingUp, false);
-
-		DripstoneState state = switch (count) {
-			case 1 -> DripstoneState.Tip;
-			case 2 -> DripstoneState.Frustum;
-			default -> DripstoneState.Middle;
-		};
-
-		if (state == DripstoneState.Middle && countDripstone(world, x, y, z, pointingUp, !pointingUp, false) == 1) {
-			state = DripstoneState.Base;
-		}
-
-		int dy = pointingUp ? 1 : -1;
-
-		if (state == DripstoneState.Tip && countDripstone(world, x, y + dy, z, !pointingUp, pointingUp, false) > 0) {
-			state = DripstoneState.TipMerge;
-		}
-
+		DripstoneState state = computeState(world, x, y, z, pointingUp, false);
 		int meta = this.up.getMetaPrimitive(pointingUp, 0);
 		meta = this.state.getMeta(state, meta);
-
 		world.setBlockMetadataWithNotify(x, y, z, meta, 3);
 	}
 
@@ -303,8 +282,8 @@ public class BlockPointedDripstone extends Block {
 			super.onFallenUpon(world, x, y, z, entity, fallDistance);
 			return;
 		}
-		DripstoneState s = state.getValue(world, x, y, z);
-		if (s != DripstoneState.Tip && s != DripstoneState.TipMerge) {
+		DripstoneState state = this.state.getValue(world, x, y, z);
+		if (state != DripstoneState.Tip && state != DripstoneState.TipMerge) {
 			super.onFallenUpon(world, x, y, z, entity, fallDistance);
 			return;
 		}
@@ -318,10 +297,8 @@ public class BlockPointedDripstone extends Block {
 		}
 	}
 
-	@Override
-	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-		DripstoneState state = this.state.getValue(world, x, y, z);
-
+	/// Returns the XZ inset (in block fractions) for a given dripstone state.
+	private static float boundsOffset(DripstoneState state) {
 		int shrinkage = switch (state) {
 			case Base -> 0;
 			case Middle -> 1;
@@ -329,40 +306,31 @@ public class BlockPointedDripstone extends Block {
 			case Tip, TipMerge -> 3;
 		};
 
-		float pixel = 0.0625f;
-		float offset = (float) (shrinkage + 2) * pixel;
+		return (shrinkage + 2) * 0.0625f;
+	}
 
+	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
+		DripstoneState state = this.state.getValue(world, x, y, z);
+		float offset = boundsOffset(state);
 		if (state == DripstoneState.Tip) {
 			boolean pointingUp = this.up.getBooleanValue(world, x, y, z);
-
-			return AxisAlignedBB.getBoundingBox(
-				x + offset, y + (pointingUp ? 0F : pixel * 5), z + offset,
-				x + (1 - offset), y + (pointingUp ? pixel * 11 : 1.0F), z + (1 - offset)
-			);
-		} else {
-			return AxisAlignedBB.getBoundingBox(x + offset, y, z + offset, x + (1 - offset), y + 1.0F, z + (1 - offset));
+			float minY = pointingUp ? 0F : 5 * 0.0625f;
+			float maxY = pointingUp ? 11 * 0.0625f : 1.0F;
+			return AxisAlignedBB.getBoundingBox(x + offset, y + minY, z + offset, x + (1 - offset), y + maxY, z + (1 - offset));
 		}
+		return AxisAlignedBB.getBoundingBox(x + offset, y, z + offset, x + (1 - offset), y + 1.0F, z + (1 - offset));
 	}
 
 	@Override
 	public void setBlockBoundsBasedOnState(IBlockAccess access, int x, int y, int z) {
 		DripstoneState state = this.state.getValue(access, x, y, z);
-
-		int shrinkage = switch (state) {
-			case Base -> 0;
-			case Middle -> 1;
-			case Frustum -> 2;
-			case Tip, TipMerge -> 3;
-		};
-
-		float pixel = 0.0625f;
-
-		float offset = (float) (shrinkage + 2) * pixel;
-
+		float offset = boundsOffset(state);
 		if (state == DripstoneState.Tip) {
 			boolean pointingUp = this.up.getBooleanValue(access, x, y, z);
-
-			this.setBlockBounds(offset, pointingUp ? 0F : pixel * 5, offset, 1 - offset, pointingUp ? pixel * 11 : 1.0F, 1 - offset);
+			float minY = pointingUp ? 0F : 5 * 0.0625f;
+			float maxY = pointingUp ? 11 * 0.0625f : 1.0F;
+			this.setBlockBounds(offset, minY, offset, 1 - offset, maxY, 1 - offset);
 		} else {
 			this.setBlockBounds(offset, 0, offset, 1 - offset, 1.0F, 1 - offset);
 		}
@@ -372,9 +340,9 @@ public class BlockPointedDripstone extends Block {
 	public boolean canBlockStay(World world, int x, int y, int z) {
 		boolean pointingUp = up.getBooleanValue(world, x, y, z);
 
-		int baseY = y - (pointingUp ? 1 : -1);
+		int supportY = y - (pointingUp ? 1 : -1);
 
-		if (world.isSideSolid(x, baseY, z, pointingUp ? ForgeDirection.UP : ForgeDirection.DOWN)) return true;
+		if (world.isSideSolid(x, supportY, z, pointingUp ? ForgeDirection.UP : ForgeDirection.DOWN)) return true;
 
 		return countDripstone(world, x, y, z, pointingUp, !pointingUp, false) > 1;
 	}
@@ -407,28 +375,8 @@ public class BlockPointedDripstone extends Block {
 		return "pointed_dripstone";
 	}
 
-	/**
-	 * Returns the number of contiguous down-pointing dripstone blocks starting from
-	 * the base and scanning downward. Returns at most 12 to bound the search.
-	 */
-	private int stalactiteLength(World world, int x, int baseY, int z) {
-		int count = 0;
-		int scanY = baseY;
-
-		while (count <= 11) {
-			if (world.getBlock(x, scanY, z) != this) break;
-			if (up.getBooleanValue(world, x, scanY, z)) break;
-			count++;
-			scanY--;
-		}
-
-		return count;
-	}
-
-	/**
-	 * Scans downward from the base to find the Y coordinate of the tip.
-	 * Returns -1 if no tip is found within 11 blocks or if a non-stalactite block is encountered.
-	 */
+	/// Scans downward from the base to find the Y coordinate of the tip.
+	/// Returns -1 if no tip is found within 11 blocks or if a non-stalactite block is encountered.
 	private int findStalactiteTipY(World world, int x, int baseY, int z) {
 		int scanY = baseY;
 
@@ -436,8 +384,8 @@ public class BlockPointedDripstone extends Block {
 			if (world.getBlock(x, scanY, z) != this) return -1;
 			if (up.getBooleanValue(world, x, scanY, z)) return -1;
 
-			DripstoneState s = state.getValue(world, x, scanY, z);
-			if (s == DripstoneState.Tip || s == DripstoneState.TipMerge) return scanY;
+			DripstoneState state = this.state.getValue(world, x, scanY, z);
+			if (state == DripstoneState.Tip || state == DripstoneState.TipMerge) return scanY;
 
 			scanY--;
 		}
@@ -445,29 +393,21 @@ public class BlockPointedDripstone extends Block {
 		return -1;
 	}
 
-	/**
-	 * Scans upward from the tip to find the Y coordinate of the base.
-	 * Returns -1 if no base is found within 11 blocks or if a non-stalactite block is encountered.
-	 */
+	/// Returns the Y offset from the stalactite tip to the base (0 = single block, n = n+1 blocks tall).
+	/// Caps at 11. `baseY = tipY + offset`.
 	private int findStalactiteTopOffset(World world, int x, int tipY, int z) {
-		int scanY = tipY;
-
-		int i;
-
-		for (i = 0; i <= 11; i++) {
+		int offset = 0;
+		while (offset <= 11) {
+			int scanY = tipY + offset;
 			if (world.getBlock(x, scanY, z) != this) break;
 			if (up.getBooleanValue(world, x, scanY, z)) break;
-
-			scanY++;
+			offset++;
 		}
-
-		return i - 1;
+		return offset - 1;
 	}
 
-	/**
-	 * Returns the Forge {@link Fluid} at the given position if it is a fluid source block
-	 * (meta == 0), or {@code null} if the block is not a fluid or is a flowing fluid.
-	 */
+	/// Returns the Forge [Fluid] at the given position if it is a fluid source block
+	/// (meta == 0), or `null` if the block is not a fluid or is a flowing fluid.
 	@Nullable
 	private Fluid fluidSourceAt(World world, int x, int y, int z) {
 		Block block = world.getBlock(x, y, z);
@@ -479,10 +419,7 @@ public class BlockPointedDripstone extends Block {
 
 	private final BlockStatePool pool = new BlockStatePool(4);
 
-	/**
-	 * Returns true if a block allows drip to pass through it.
-	 * Covers air, ladders, open trapdoors, signs, torches, and any block with no collision box.
-	 */
+	/// Returns true if a block allows drip to pass through it.
 	private boolean isPassable(World world, int x, int y, int z, Block block) {
 		if (block instanceof BlockTrapDoor) {
 			try (BlockState state = BlockPropertyRegistry.getBlockState(pool, world, x, y, z)) {
@@ -493,39 +430,35 @@ public class BlockPointedDripstone extends Block {
 		return block.getCollisionBoundingBoxFromPool(world, x, y, z) == null;
 	}
 
-	/**
-	 * Scans downward from just below the tip to find a cauldron within 10 blocks.
-	 * Stops early if a non-passable, non-target block is encountered.
-	 * Returns the Y coordinate of the cauldron, or -1 if none is reachable.
-	 */
+	/// Scans downward from just below the tip to find a cauldron within 10 blocks.
+	/// Stops early if a non-passable, non-target block is encountered.
+	/// Returns the Y coordinate of the cauldron, or -1 if none is reachable.
 	private int findCauldronY(World world, int x, int tipY, int z) {
 		for (int y = tipY - 1; y >= tipY - 10; y--) {
-			Block b = world.getBlock(x, y, z);
+			Block block = world.getBlock(x, y, z);
 
-			if (b instanceof BlockCauldron || b instanceof BlockCauldronTileEntity) return y;
+			if (block instanceof BlockCauldron || block instanceof BlockCauldronTileEntity) return y;
 
-			if (!isPassable(world, x, y, z, b)) return -1;
+			if (!isPassable(world, x, y, z, block)) return -1;
 		}
 
 		return -1;
 	}
 
-	/**
-	 * Scans downward from just below the stalactite tip to find a stalagmite (up=true) Tip,
-	 * or a solid surface where a new stalagmite tip can start.
-	 * Returns the Y coordinate of the existing stalagmite tip or the empty slot above a solid surface,
-	 * or -1 if the path is blocked or nothing suitable is found.
-	 */
+	/// Scans downward from just below the stalactite tip to find a stalagmite (up=true) Tip,
+	/// or a solid surface where a new stalagmite tip can start.
+	/// Returns the Y coordinate of the existing stalagmite tip or the empty slot above a solid surface,
+	/// or -1 if the path is blocked or nothing suitable is found.
 	private int findStalagmiteTipY(World world, int x, int tipY, int z) {
 		for (int y = tipY - 1; y >= tipY - 10; y--) {
-			Block b = world.getBlock(x, y, z);
+			Block block = world.getBlock(x, y, z);
 
-			if (b == this && up.getBooleanValue(world, x, y, z)) {
-				DripstoneState s = state.getValue(world, x, y, z);
-				return s == DripstoneState.Tip || s == DripstoneState.TipMerge ? y : -1;
+			if (block == this && up.getBooleanValue(world, x, y, z)) {
+				DripstoneState dripState = state.getValue(world, x, y, z);
+				return dripState == DripstoneState.Tip || dripState == DripstoneState.TipMerge ? y : -1;
 			}
 
-			if (!isPassable(world, x, y, z, b)) {
+			if (!isPassable(world, x, y, z, block)) {
 				// Solid block: y+1 is the slot for a new stalagmite tip
 				if (world.isSideSolid(x, y, z, ForgeDirection.UP) && world.isAirBlock(x, y + 1, z)) {
 					return y + 1;
@@ -537,10 +470,8 @@ public class BlockPointedDripstone extends Block {
 		return -1;
 	}
 
-	/**
-	 * Places a new Tip block one step in the growth direction and updates the surrounding states.
-	 * Assumption: the target block at growY must be air before calling this.
-	 */
+	/// Places a new Tip block one step in the growth direction and updates the surrounding states.
+	/// Assumption: the target block at growY must be air before calling this.
 	private void growTip(World world, int x, int tipY, int z, boolean pointingUp) {
 		int growY = tipY + (pointingUp ? 1 : -1);
 
@@ -550,11 +481,9 @@ public class BlockPointedDripstone extends Block {
 		updateState(world, x, tipY, z);
 	}
 
-	/**
-	 * Attempts to grow the stalactite tip downward or a stalagmite tip upward.
-	 * Fires from the TIP block's random tick. Requires a dripstone_block above the base,
-	 * a water source 2 above the base, max length 8, and a 64/5625 chance (~1.138%).
-	 */
+	/// Attempts to grow the stalactite tip downward or a stalagmite tip upward.
+	/// Fires from the TIP block's random tick. Requires a dripstone\_block above the base,
+	/// a water source 2 above the base, max length 8, and a 64/5625 chance (\~1.138%).
 	private void tryGrow(World world, int x, int tipY, int z, Random rand) {
 		int topOffset = findStalactiteTopOffset(world, x, tipY, z);
 		int baseY = tipY + topOffset;
@@ -626,7 +555,7 @@ public class BlockPointedDripstone extends Block {
 		int tipY = findStalactiteTipY(world, x, y, z);
 		if (tipY < 0) return;
 
-		if (stalactiteLength(world, x, y, z) > 10) return;
+		if (y - tipY + 1 > 10) return;
 
 		int cauldronY = findCauldronY(world, x, tipY, z);
 		if (cauldronY < 0) return;
@@ -641,17 +570,16 @@ public class BlockPointedDripstone extends Block {
 
 		if (up.getBooleanValue(world, x, y, z)) return;
 
-		DripstoneState currentState = state.getValue(world, x, y, z);
-		if (currentState != DripstoneState.Tip && currentState != DripstoneState.TipMerge) return;
-
 		// TipMerge is the analog of a waterlogged tip — no drip particles
-		if (currentState == DripstoneState.TipMerge) return;
+		if (state.getValue(world, x, y, z) != DripstoneState.Tip) return;
 
 		int topOffset = findStalactiteTopOffset(world, x, y, z);
 		if (topOffset < 0 || topOffset >= 11) return;
 
+		int fluidSourceY = y + topOffset + 2;
+
 		// The fluid source must be 2 blocks above the base (1 block above the solid support).
-		Fluid fluid = fluidSourceAt(world, x, y + topOffset + 2, z);
+		Fluid fluid = fluidSourceAt(world, x, fluidSourceY, z);
 		if (fluid == null) {
 			// Fluid-less = 3x slower drips
 			if (rand.nextInt(3) != 0) return;
@@ -662,7 +590,7 @@ public class BlockPointedDripstone extends Block {
 		int color;
 
 		if (fluid == FluidRegistry.WATER) {
-			RGBColor mult = RGBColor.fromRGB(Blocks.water.colorMultiplier(world, x, y + topOffset + 2, z));
+			RGBColor mult = RGBColor.fromRGB(Blocks.water.colorMultiplier(world, x, fluidSourceY, z));
 			RGBColor base = RGBColor.fromRGB(MapColor.waterColor.colorValue);
 
 			base.red = base.red * mult.red / 255;
@@ -673,14 +601,14 @@ public class BlockPointedDripstone extends Block {
 		} else if (fluid == FluidRegistry.LAVA) {
 			color = 0xff7813;
 		} else {
-			color = fluid.getColor(world, x, y + topOffset + 2, z);
+			color = fluid.getColor(world, x, fluidSourceY, z);
 		}
 
 		setBlockBoundsBasedOnState(world, x, y, z);
 
-		double px = x + minX + (maxX - minX) * 0.5;
-		double pz = z + minZ + (maxZ - minZ) * 0.5;
+		double particleX = x + minX + (maxX - minX) * 0.5;
+		double particleZ = z + minZ + (maxZ - minZ) * 0.5;
 
-		CustomParticles.spawnDrippingParticle(world, px, y + minY - 0.05f, pz, color | 0xFF000000);
+		CustomParticles.spawnDrippingParticle(world, particleX, y + minY - 0.05f, particleZ, color | 0xFF000000);
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockPointedDripstone.java
@@ -1,14 +1,22 @@
 package ganymedes01.etfuturum.blocks;
 
+import java.lang.reflect.Type;
+
+import com.gtnewhorizon.gtnhlib.blockstate.core.BlockPropertyTrait;
+import com.gtnewhorizon.gtnhlib.blockstate.core.MetaBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.properties.BooleanBlockProperty.BooleanMetaBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.registry.BlockPropertyRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.EtFuturum;
 import ganymedes01.etfuturum.client.sound.ModSounds;
 import ganymedes01.etfuturum.core.utils.Utils;
+import ganymedes01.etfuturum.entities.EntityFallingDripstone;
 import ganymedes01.etfuturum.lib.RenderIDs;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.init.Blocks;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.IIcon;
@@ -18,11 +26,75 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 public class BlockPointedDripstone extends Block {
 
-	private IIcon[] downIcons;
-	private IIcon[] upIcons;
-	private static final int states = 5;
+	public final BooleanMetaBlockProperty up = new BooleanMetaBlockProperty() {
 
-	public static DamageSource STALACTITE_DAMAGE;
+		@Override
+		public String getName() {
+			return "up";
+		}
+
+		@Override
+		public boolean hasTrait(BlockPropertyTrait trait) {
+			return switch (trait) {
+				case SupportsWorld, OnlyNeedsMeta, WorldMutable, Primitive, MetaPrimitive, SupportsStacks, StackMutable -> true;
+				default -> false;
+			};
+		}
+
+		@Override
+		public int getMetaPrimitive(boolean value, int existing) {
+			return (existing % 5) + (value ? 5 : 0);
+		}
+
+		@Override
+		public boolean getValuePrimitive(int meta) {
+			return meta >= 5;
+		}
+	};
+
+	public final MetaBlockProperty<DripstoneState> state = new MetaBlockProperty<>() {
+
+		@Override
+		public int getMeta(DripstoneState state, int existing) {
+			return (existing >= 5 ? 5 : 0) + state.ordinal();
+		}
+
+		@Override
+		public DripstoneState getValue(int meta) {
+			return DripstoneState.STATES[meta % 5];
+		}
+
+		@Override
+		public String getName() {
+			return "state";
+		}
+
+		@Override
+		public Type getType() {
+			return DripstoneState.class;
+		}
+
+		@Override
+		public boolean hasTrait(BlockPropertyTrait trait) {
+			return switch (trait) {
+				case SupportsWorld, OnlyNeedsMeta, WorldMutable, SupportsStacks, StackMutable -> true;
+				default -> false;
+			};
+		}
+	};
+
+	public enum DripstoneState {
+		Base,
+		Middle,
+		Frustum,
+		Tip,
+		TipMerge;
+
+		public IIcon upIcon, downIcon;
+		private static final DripstoneState[] STATES = values();
+	}
+
+	public static final DamageSource STALACTITE_DAMAGE = new DamageSource("stalactite");
 
 	public BlockPointedDripstone() {
 		super(Material.rock);
@@ -33,105 +105,219 @@ public class BlockPointedDripstone extends Block {
 		this.setBlockName(Utils.getUnlocalisedName("pointed_dripstone"));
 		this.setBlockTextureName("pointed_dripstone");
 		this.setCreativeTab(EtFuturum.creativeTabBlocks);
+
+		BlockPropertyRegistry.registerProperty(this, up);
+		BlockPropertyRegistry.registerProperty(this, state);
 	}
 
 	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerBlockIcons(IIconRegister reg) {
-		downIcons = new IIcon[5];
-		downIcons[0] = reg.registerIcon(getTextureName() + "_down_tip");
-		downIcons[1] = reg.registerIcon(getTextureName() + "_down_frustum");
-		downIcons[2] = reg.registerIcon(getTextureName() + "_down_middle");
-		downIcons[3] = reg.registerIcon(getTextureName() + "_down_base");
-		downIcons[4] = reg.registerIcon(getTextureName() + "_down_tip_merge");
+		DripstoneState.Base.downIcon = reg.registerIcon(getTextureName() + "_down_base");
+		DripstoneState.Middle.downIcon = reg.registerIcon(getTextureName() + "_down_middle");
+		DripstoneState.Frustum.downIcon = reg.registerIcon(getTextureName() + "_down_frustum");
+		DripstoneState.Tip.downIcon = reg.registerIcon(getTextureName() + "_down_tip");
+		DripstoneState.TipMerge.downIcon = reg.registerIcon(getTextureName() + "_down_tip_merge");
 
-		upIcons = new IIcon[5];
-		upIcons[0] = reg.registerIcon(getTextureName() + "_up_tip");
-		upIcons[1] = reg.registerIcon(getTextureName() + "_up_frustum");
-		upIcons[2] = reg.registerIcon(getTextureName() + "_up_middle");
-		upIcons[3] = reg.registerIcon(getTextureName() + "_up_base");
-		upIcons[4] = reg.registerIcon(getTextureName() + "_up_tip_merge");
+		DripstoneState.Base.upIcon = reg.registerIcon(getTextureName() + "_up_base");
+		DripstoneState.Middle.upIcon = reg.registerIcon(getTextureName() + "_up_middle");
+		DripstoneState.Frustum.upIcon = reg.registerIcon(getTextureName() + "_up_frustum");
+		DripstoneState.Tip.upIcon = reg.registerIcon(getTextureName() + "_up_tip");
+		DripstoneState.TipMerge.upIcon = reg.registerIcon(getTextureName() + "_up_tip_merge");
+	}
 
-		this.blockIcon = downIcons[3];
+	private int countDripstone(World world, int x, int y, int z, boolean pointingUp, boolean scanUp, boolean skipFirst) {
+		int count = 0;
+
+		int deltaY = scanUp ? 1 : -1;
+
+		if (skipFirst) {
+			count++;
+			y += deltaY;
+		}
+
+		for (int i = 0; i < 3; i++) {
+			if (world.getBlock(x, y, z) != this) break;
+
+			boolean isUp = this.up.getBooleanValue(world, x, y, z);
+
+			if (isUp != pointingUp) break;
+
+			y += deltaY;
+			count++;
+		}
+
+		return count;
 	}
 
 	@Override
 	public int onBlockPlaced(World world, int x, int y, int z, int side, float subX, float subY, float subZ, int meta) {
-		if (side < 2) {
-			return side * states;
+		ForgeDirection dir = ForgeDirection.getOrientation(side);
+
+		boolean pointingUp = dir == ForgeDirection.UP;
+
+		int count = countDripstone(world, x, y, z, pointingUp, pointingUp, true);
+
+		DripstoneState state = switch (count) {
+			case 1 -> DripstoneState.Tip;
+			case 2 -> DripstoneState.Frustum;
+			default -> DripstoneState.Middle;
+		};
+
+		if (state == DripstoneState.Middle && countDripstone(world, x, y, z, pointingUp, !pointingUp, true) == 1) {
+			state = DripstoneState.Base;
 		}
-		if (canDripstoneStayHere(world, x, y, z, -1)) {
-			return states;
+
+		int dy = pointingUp ? 1 : -1;
+
+		if (state == DripstoneState.Tip && countDripstone(world, x, y + dy, z, !pointingUp, pointingUp, false) > 0) {
+			state = DripstoneState.TipMerge;
 		}
-		return 0;
+
+		meta = this.up.getMetaPrimitive(pointingUp, 0);
+		meta = this.state.getMeta(state, meta);
+
+		return meta;
 	}
 
 	@Override
 	public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side) {
-		int checkY = side == 0 || world.isSideSolid(x, y + 1, z, ForgeDirection.DOWN) ? 1 : -1;
-		return canDripstoneStayHere(world, x, y, z, checkY);
+		ForgeDirection dir = ForgeDirection.getOrientation(side);
+
+		if (dir == ForgeDirection.DOWN) {
+			return world.isSideSolid(x, y + 1, z, ForgeDirection.DOWN) || world.getBlock(x, y + 1, z) == this;
+		}
+
+		if (dir == ForgeDirection.UP) {
+			return world.isSideSolid(x, y - 1, z, ForgeDirection.UP) || world.getBlock(x, y - 1, z) == this;
+		}
+
+		return false;
 	}
+
+	private boolean collapsing = false;
 
 	@Override
 	public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
-		if (!canBlockStay(world, x, y, z)) {
-			world.setBlockToAir(x, y, z);
-			this.dropBlockAsItem(world, x, y, z, 0, 0);
+		if (canBlockStay(world, x, y, z)) {
+			updateState(world, x, y, z);
 			return;
 		}
-		setState(world, x, y, z);
+
+		if (collapsing) return;
+
+		if (up.getBooleanValue(world, x, y, z)) {
+			world.setBlockToAir(x, y, z);
+			this.dropBlockAsItem(world, x, y, z, 0, 0);
+		} else {
+			collapseHangingColumn(world, x, y, z);
+		}
+	}
+
+	/**
+	 * Clears the whole contiguous run of down-pointing dripstone hanging below (x,y,z) in one
+	 * synchronous pass and spawns a single falling entity for it, rather than one entity per block.
+	 * Doing this atomically (instead of relying on onNeighborBlockChange to cascade block-by-block
+	 * across ticks) avoids a race where a redundant notification for a still-standing block spawns a
+	 * competing entity before the first one gets a chance to remove it.
+	 */
+	private void collapseHangingColumn(World world, int x, int y, int z) {
+		int meta = world.getBlockMetadata(x, y, z);
+
+		int count = 0;
+		int y2 = y;
+
+		this.collapsing = true;
+
+		while (!up.getBooleanValue(world, x, y2, z) && world.getBlock(x, y2, z) == this) {
+			world.setBlock(x, y2, z, Blocks.air, 0, 2);
+			y2--;
+			count++;
+		}
+
+		this.collapsing = false;
+
+		if (count > 0 && !world.isRemote) {
+			world.spawnEntityInWorld(new EntityFallingDripstone(world, x + 0.5D, y + 0.5D, z + 0.5D, meta, count));
+		}
+	}
+
+	private void updateState(World world, int x, int y, int z) {
+		boolean pointingUp = up.getBooleanValue(world, x, y, z);
+
+		int count = countDripstone(world, x, y, z, pointingUp, pointingUp, false);
+
+		DripstoneState state = switch (count) {
+			case 1 -> DripstoneState.Tip;
+			case 2 -> DripstoneState.Frustum;
+			default -> DripstoneState.Middle;
+		};
+
+		if (state == DripstoneState.Middle && countDripstone(world, x, y, z, pointingUp, !pointingUp, false) == 1) {
+			state = DripstoneState.Base;
+		}
+
+		int dy = pointingUp ? 1 : -1;
+
+		if (state == DripstoneState.Tip && countDripstone(world, x, y + dy, z, !pointingUp, pointingUp, false) > 0) {
+			state = DripstoneState.TipMerge;
+		}
+
+		int meta = this.up.getMetaPrimitive(pointingUp, 0);
+		meta = this.state.getMeta(state, meta);
+
+		world.setBlockMetadataWithNotify(x, y, z, meta, 3);
 	}
 
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-		int meta = world.getBlockMetadata(x, y, z);
-		if (meta % 5 == 4) meta = 0;
-		float offset = 0.0625F + ((float) (2 - meta % states) * 0.125F);
+		DripstoneState state = this.state.getValue(world, x, y, z);
+
+		int shrinkage = switch (state) {
+            case Base -> 0;
+            case Middle -> 1;
+            case Frustum -> 2;
+            case Tip, TipMerge -> 3;
+        };
+
+		float offset = 0.125F + (float) shrinkage * 0.0625F;
 
 		return AxisAlignedBB.getBoundingBox(x + offset, y, z + offset, x + (1 - offset), y + 1.0F, z + (1 - offset));
 	}
 
 	@Override
 	public void setBlockBoundsBasedOnState(IBlockAccess access, int x, int y, int z) {
-		int meta = access.getBlockMetadata(x, y, z);
-		if (meta % 5 == 4) meta = 0;
-		float offset = 0.0625F + ((float) (2 - meta % states) * 0.0625F);
+		DripstoneState state = this.state.getValue(access, x, y, z);
+
+		int shrinkage = switch (state) {
+			case Base -> 0;
+			case Middle -> 1;
+			case Frustum -> 2;
+			case Tip, TipMerge -> 3;
+		};
+
+		float offset = 0.125F + (float) shrinkage * 0.0625F;
 
 		this.setBlockBounds(offset, 0, offset, 1 - offset, 1.0F, 1 - offset);
 	}
 
-	private void setState(World world, int x, int y, int z) {
-		int meta = 0;
-		boolean up = world.getBlockMetadata(x, y, z) > 4;
-		for (meta = 0; meta < 2; meta++) {
-			if (world.getBlockMetadata(x, y + (up ? 1 : -1) + (up ? meta : -meta), z) > 4 != up || world.getBlock(x, y + (up ? 1 : -1) + (up ? meta : -meta), z) != this) {
-				break;
-			}
-		}
-		if (meta % 5 == 0 && world.getBlock(x, y + (up ? 1 : -1), z) == this && world.getBlockMetadata(x, y + (up ? 1 : -1), z) > 4 != up) {
-			meta = 4;
-		}
-		if (meta % 5 == 2 && world.getBlock(x, y + (up ? 1 : -1), z) == this && world.getBlockMetadata(x, y + (up ? 1 : -1), z) % 5 == 2
-				&& world.getBlock(x, y + (up ? -1 : 1), z).isSideSolid(world, x, y + (up ? -1 : 1), z, up ? ForgeDirection.DOWN : ForgeDirection.UP)) {
-			meta = 3;
-		}
-		if (up) meta += states;
-		world.setBlockMetadataWithNotify(x, y, z, meta, 3);
-	}
-
 	@Override
 	public boolean canBlockStay(World world, int x, int y, int z) {
-		int checkY = world.getBlockMetadata(x, y, z) < states ? 1 : -1;
-		return canDripstoneStayHere(world, x, y, z, checkY);
-	}
+		boolean pointingUp = up.getBooleanValue(world, x, y, z);
 
-	private boolean canDripstoneStayHere(World world, int x, int y, int z, int offset) {
-		return world.isBlockNormalCubeDefault(x, y + offset, z, false) || (offset == (world.getBlockMetadata(x, y + offset, z) < states ? 1 : -1) && world.getBlock(x, y + offset, z) == this);
+		int baseY = y - (pointingUp ? 1 : -1);
+
+		if (world.isSideSolid(x, baseY, z, pointingUp ? ForgeDirection.UP : ForgeDirection.DOWN)) return true;
+
+		return countDripstone(world, x, y, z, pointingUp, !pointingUp, false) > 1;
 	}
 
 	@Override
 	public IIcon getIcon(int side, int meta) {
-		return meta < states ? downIcons[meta % states] : upIcons[meta % states];
+		DripstoneState state = this.state.getValue(meta);
+		boolean pointingUp = up.getValuePrimitive(meta);
+
+		return pointingUp ? state.upIcon : state.downIcon;
 	}
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/client/particle/CustomDripFX.java
+++ b/src/main/java/ganymedes01/etfuturum/client/particle/CustomDripFX.java
@@ -1,9 +1,12 @@
 package ganymedes01.etfuturum.client.particle;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.particle.EntityFX;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public class CustomDripFX extends EntityFX {
@@ -14,6 +17,9 @@ public class CustomDripFX extends EntityFX {
 
 	public CustomDripFX(World worldIn, double p_i1203_2_, double p_i1203_4_, double p_i1203_6_, String dripSound, int color, boolean splashes) {
 		super(worldIn, p_i1203_2_, p_i1203_4_, p_i1203_6_, 0, 0, 0);
+		this.prevPosX = this.posX;
+		this.prevPosY = this.posY;
+		this.prevPosZ = this.posZ;
 		this.motionX = this.motionY = this.motionZ = 0.0D;
 		particleAlpha = (color >> 24 & 0xff) / 255F;
 		particleRed = (color >> 16 & 0xff) / 255F;
@@ -24,6 +30,7 @@ public class CustomDripFX extends EntityFX {
 
 		this.setParticleTextureIndex(113);
 		this.setSize(0.01F, 0.01F);
+		this.setPosition(this.posX, this.posY, this.posZ); // re-center bbox; setSize shrink doesn't call setPosition
 		this.particleGravity = 0.06F;
 		this.bobTimer = 40;
 		this.particleMaxAge = (int) (64.0D / (Math.random() * 0.8D + 0.2D));
@@ -74,12 +81,27 @@ public class CustomDripFX extends EntityFX {
 			this.motionZ *= 0.699999988079071D;
 		}
 
-		Material material = this.worldObj.getBlock(MathHelper.floor_double(this.posX), MathHelper.floor_double(this.posY), MathHelper.floor_double(this.posZ)).getMaterial();
+		int bX = MathHelper.floor_double(this.posX);
+		int bY = MathHelper.floor_double(this.posY);
+		int bZ = MathHelper.floor_double(this.posZ);
 
-		if (material.isLiquid() || material.isSolid()) {
-			double d0 = (float) (MathHelper.floor_double(this.posY) + 1) - BlockLiquid.getLiquidHeightPercent(this.worldObj.getBlockMetadata(MathHelper.floor_double(this.posX), MathHelper.floor_double(this.posY), MathHelper.floor_double(this.posZ)));
+		Block block = this.worldObj.getBlock(bX, bY, bZ);
+		int meta = this.worldObj.getBlockMetadata(bX, bY, bZ);
+
+		Material material = block.getMaterial();
+
+		if (material.isLiquid()) {
+			double d0 = (float) (bY + 1) - BlockLiquid.getLiquidHeightPercent(meta);
 
 			if (this.posY < d0) {
+				this.setDead();
+			}
+		} else if (material.isSolid()) {
+			block.setBlockBoundsBasedOnState(worldObj, bX, bY, bZ);
+
+			AxisAlignedBB aabb = block.getCollisionBoundingBoxFromPool(worldObj, bX, bY, bZ);
+
+			if (aabb.isVecInside(Vec3.createVectorHelper(this.posX, this.posY, this.posZ))) {
 				this.setDead();
 			}
 		}

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/entity/FallingDripstoneRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/entity/FallingDripstoneRenderer.java
@@ -2,83 +2,75 @@ package ganymedes01.etfuturum.client.renderer.entity;
 
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.entities.EntityFallingDripstone;
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.item.EntityFallingBlock;
+import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
 
 public class FallingDripstoneRenderer extends Render {
-	private final RenderBlocks field_147920_a = new RenderBlocks();
+
+	private final RenderBlocks renderBlocks = new RenderBlocks();
 
 	public FallingDripstoneRenderer() {
 		this.shadowSize = 0.5F;
 	}
 
-	/**
-	 * Actually renders the given argument. This is a synthetic bridge method, always casting down its argument and then
-	 * handing it off to a worker function which does the actual work. In all probabilty, the class Render is generic
-	 * (Render<T extends Entity) and this method has signature public void func_76986_a(T entity, double d, double d1,
-	 * double d2, float f, float f1). But JAD is pre 1.5 so doesn't do that.
-	 */
-	public void doRender(EntityFallingDripstone p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_, float p_76986_8_, float p_76986_9_) {
-		World world = p_76986_1_.func_145807_e(); // getWorldObj
-		Block block = ModBlocks.POINTED_DRIPSTONE.get();
-		int i = MathHelper.floor_double(p_76986_1_.posX);
-		int j = MathHelper.floor_double(p_76986_1_.posY);
-		int k = MathHelper.floor_double(p_76986_1_.posZ);
+	public void doRender(EntityFallingDripstone entity, double x, double y, double z, float yaw, float partialTick) {
+		int bx = MathHelper.floor_double(entity.posX);
+		int by = MathHelper.floor_double(entity.posY);
+		int bz = MathHelper.floor_double(entity.posZ);
 
-		if (block != null && block != world.getBlock(i, j, k)) {
-			GL11.glPushMatrix();
-			GL11.glTranslatef((float) p_76986_2_, (float) p_76986_4_, (float) p_76986_6_);
-			this.bindEntityTexture(p_76986_1_);
-			GL11.glDisable(GL11.GL_LIGHTING);
-			Tessellator tessellator;
+		if (ModBlocks.POINTED_DRIPSTONE.get() == entity.worldObj.getBlock(bx, by, bz)) return;
 
-			this.field_147920_a.blockAccess = world;
-			tessellator = Tessellator.instance;
-			tessellator.startDrawingQuads();
-			tessellator.setTranslation((float) (-i) - 0.5F, (float) (-j) - 0.5F, (float) (-k) - 0.5F);
-			field_147920_a.setRenderBoundsFromBlock(block);
-			field_147920_a.drawCrossedSquares(ModBlocks.POINTED_DRIPSTONE.get().getIcon(0, p_76986_1_.field_145814_a), i, j, k, 1.0F);
-			tessellator.setTranslation(0.0D, 0.0D, 0.0D);
-			tessellator.draw();
-			this.field_147920_a.blockAccess = null;
+		GL11.glPushMatrix();
+		GL11.glTranslatef((float) x, (float) y, (float) z);
+		this.bindEntityTexture(entity);
+		GL11.glDisable(GL11.GL_LIGHTING);
 
-			GL11.glEnable(GL11.GL_LIGHTING);
-			GL11.glPopMatrix();
+		renderBlocks.blockAccess = entity.worldObj;
+		Tessellator tess = Tessellator.instance;
+		tess.startDrawingQuads();
+		tess.setTranslation(-bx - 0.5F, -by - 0.5F, -bz - 0.5F);
+		renderBlocks.setRenderBoundsFromBlock(ModBlocks.POINTED_DRIPSTONE.get());
+
+		boolean isUp = entity.field_145814_a >= 5;
+		int count = entity.getCount();
+		for (int n = 0; n < count; n++) {
+			int segMeta = (isUp ? 5 : 0) + stateOrdinalForSegment(n, count);
+			IIcon icon = ModBlocks.POINTED_DRIPSTONE.get().getIcon(0, segMeta);
+			renderBlocks.drawCrossedSquares(icon, bx, by - n, bz, 1.0F);
 		}
+
+		tess.setTranslation(0, 0, 0);
+		tess.draw();
+		renderBlocks.blockAccess = null;
+
+		GL11.glEnable(GL11.GL_LIGHTING);
+		GL11.glPopMatrix();
 	}
 
-	/**
-	 * Returns the location of an entity's texture. Doesn't seem to be called unless you call Render.bindEntityTexture.
-	 */
-	protected ResourceLocation getEntityTexture(EntityFallingBlock p_110775_1_) {
+	// Returns the DripstoneState ordinal (Base=0, Middle=1, Frustum=2, Tip=3) for segment n in a column of `count`.
+	// n=0 is the topmost block; n=count-1 is the tip.
+	private static int stateOrdinalForSegment(int n, int count) {
+		int countDown = count - n;
+		if (countDown == 1) return 3; // Tip
+		if (countDown == 2) return 2; // Frustum
+		if (n == 1)         return 0; // Base
+		return 1;                     // Middle
+	}
+
+	@Override
+	protected ResourceLocation getEntityTexture(Entity entity) {
 		return TextureMap.locationBlocksTexture;
 	}
 
-	/**
-	 * Returns the location of an entity's texture. Doesn't seem to be called unless you call Render.bindEntityTexture.
-	 */
 	@Override
-	protected ResourceLocation getEntityTexture(Entity p_110775_1_) {
-		return this.getEntityTexture((EntityFallingBlock) p_110775_1_);
-	}
-
-	/**
-	 * Actually renders the given argument. This is a synthetic bridge method, always casting down its argument and then
-	 * handing it off to a worker function which does the actual work. In all probabilty, the class Render is generic
-	 * (Render<T extends Entity) and this method has signature public void func_76986_a(T entity, double d, double d1,
-	 * double d2, float f, float f1). But JAD is pre 1.5 so doesn't do that.
-	 */
-	@Override
-	public void doRender(Entity p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_, float p_76986_8_, float p_76986_9_) {
-		this.doRender((EntityFallingDripstone) p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
+	public void doRender(Entity entity, double x, double y, double z, float yaw, float partialTick) {
+		this.doRender((EntityFallingDripstone) entity, x, y, z, yaw, partialTick);
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigBlocksItems.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigBlocksItems.java
@@ -130,6 +130,7 @@ public class ConfigBlocksItems extends ConfigBase {
 	public static boolean enableGlowBerries;
 	public static boolean enableSoulSoil;
 	public static boolean enableSoulLighting;
+	public static boolean enableDripstone;
 
 	// Wilds Update
 	public static boolean enableMud;
@@ -161,7 +162,7 @@ public class ConfigBlocksItems extends ConfigBase {
 	public static final String catItemEntity = "entity items";
 	public static final String catItemMisc = "misc items";
 
-	public ConfigBlocksItems(File file) {
+    public ConfigBlocksItems(File file) {
 		super(file);
 		setCategoryComment(catBlockNatural, "Blocks that can generate naturally in your world. Check world.cfg for generation values.");
 		setCategoryComment(catBlockFunc, "Blocks that have a specific function, whether right clicked or otherwise.");
@@ -215,6 +216,7 @@ public class ConfigBlocksItems extends ConfigBase {
 		enableBasalt = getBoolean("enableBasalt", catBlockNatural, true, "This must be on for the basalt deltas biome to generate unless Netherlicious is installed.");
 		enableGlowLichen = getBoolean("enableGlowLichen", catBlockNatural, true, "");
 		enableGlowBerries = getBoolean("enableGlowBerries", catBlockNatural, true, "");
+		enableDripstone = getBoolean("enableDripstone", catBlockNatural, true, "");
 		if (ConfigExperiments.enableCrimsonBlocks) {
 			enableNetherwartBlock = true;
 		}

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigExperiments.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigExperiments.java
@@ -16,7 +16,6 @@ public class ConfigExperiments extends ConfigBase {
 	public static boolean enableWarpedBlocks;
 	public static boolean enableMangroveBlocks;
 	public static boolean enableMossAzalea;
-	public static boolean enableDripstone;
 	public static boolean enableLightningRod;
 
 	public static boolean netherDimensionProvider;
@@ -44,7 +43,6 @@ public class ConfigExperiments extends ConfigBase {
 		enableWarpedBlocks = getBoolean("enableWarpedBlocks", catExperiments, false, "Enables the warped nylium, wood, and plants. This must be on for the warped forest biome to generate unless Netherlicious is installed. Requires newNether to be enabled without Netherlicious.");
 		enableMangroveBlocks = getBoolean("enableMangroveBlocks", catExperiments, false, "Enables mangrove wood and all of its wood subtypes, and the roots (+ muddy versions).");
 		enableSculk = getBoolean("enableSculk", catExperiments, false, "Enables sculk-related blocks.");
-		enableDripstone = getBoolean("enableDripstone", catExperiments, false, "Partially functional. Does not naturally generate.");
 		enableMossAzalea = getBoolean("enableMossAzalea", catExperiments, false, "Enables moss and azalea. Currently azalea saplings do not grow.");
 		enableLightningRod = getBoolean("enableLightningRod", catExperiments, false, "Completely nonfunctional.");
 

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
@@ -60,6 +60,7 @@ public class ConfigWorld extends ConfigBase {
 	public static boolean amethystDimensionBlacklistAsWhitelist;
 	public static int cherryTreeRarity;
 	public static boolean bambooWorldgen;
+	public static boolean dripstoneWorldgen;
 
 	public static int crimsonForestID;
 	public static int warpedForestID;
@@ -181,6 +182,7 @@ public class ConfigWorld extends ConfigBase {
 		amethystMaxY = getInt("amethystMaxY", catGeneration, 46, 6, 245, "Max Y level amethyst geodes should attempt to generate at");
 		cherryTreeRarity = getInt("cherryTreeRarity", catGeneration, 72, 0, Byte.MAX_VALUE, "How rare should cherry trees be? 1/x chance per chunk, 1 means a tree attempts to appear every chunk. 0 = no cherry trees. They will spawn in mountain-type biomes.");
 		bambooWorldgen = getBoolean("bambooWorldgen", catGeneration, true, "Whether bamboo should naturally spawn in the overworld. Turning this off allows you to use bamboo based blocks without bamboo world gen for mod compatability.");
+		dripstoneWorldgen = getBoolean("dripstoneWorldgen", catGeneration, true, "Whether dripstone and pointed dripstone naturally spawns in the overworld.");
 
 		crimsonForestID = getInt("crimsonForestID", catBiomes, 200, -1, 65536, "Set to -1 to disable the generation of Crimson Forests. To use an ID above 255, EndlessIDs is required.");
 		warpedForestID = getInt("warpedForestID", catBiomes, 201, -1, 65536, "Set to -1 to disable the generation of Warped Forests. To use an ID above 255, EndlessIDs is required.");

--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -74,6 +74,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockCauldron;
 import net.minecraft.block.BlockEndPortalFrame;
 import net.minecraft.block.BlockFarmland;
 import net.minecraft.block.BlockLilyPad;
@@ -1015,40 +1016,8 @@ public class ServerEventHandler {
 							}
 						}
 
-						//Lava cauldron filling and cauldron filling noises
-						if (heldStack != null && canUse(player, world, x, y, z) && oldBlock == Blocks.cauldron) {
-							Item item = heldStack.getItem();
-							if (ConfigBlocksItems.enableLavaCauldrons && item instanceof ItemBucket && ((ItemBucket) item).isFull == Blocks.flowing_lava && meta == 0) {
-								event.setResult(Result.DENY);
-								player.swingItem();
-								world.setBlock(x, y, z, ModBlocks.LAVA_CAULDRON.get());
-								if (ConfigSounds.fluidInteract) {
-									world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bucket.empty_lava", 1, 1);
-								}
-								if (!player.capabilities.isCreativeMode) {
-									if (heldStack.stackSize <= 1) {
-										player.inventory.setInventorySlotContents(player.inventory.currentItem, new ItemStack(item.getContainerItem()));
-									} else {
-										--heldStack.stackSize;
-									}
-								}
-								return;
-							} else if (ConfigSounds.fluidInteract) {
-								String container = "";
-								String fillOrEmpty = "";
-								if (item instanceof ItemBucket && ((ItemBucket) item).isFull == Blocks.flowing_water && meta < 3) {
-									container = "bucket";
-									fillOrEmpty = "empty";
-								} else if (item == Items.glass_bottle || (item == Items.potionitem && heldStack.getItemDamage() == 0 && !heldStack.hasTagCompound())) {
-									container = "bottle";
-									fillOrEmpty = /* meta < 3 && item == Items.potionitem ? "empty" : */ item == Items.glass_bottle && meta > 0 ? "fill" : "";
-								}//TODO add taking from cauldrons and evaporation, and filling a cauldron with regular potion bottles
-								if (!container.equals("") && !fillOrEmpty.equals("")) {
-									world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item." + container + "." + fillOrEmpty, 1, 1);
-									return;
-								}
-							}
-						}
+						//Lava cauldron filling/emptying and cauldron filling noises
+						if (cauldronInteract(event, heldStack, player, world, x, y, z, oldBlock, meta)) return;
 
 						// --- Bottle fill sounds --- //
 						if (ConfigSounds.fluidInteract && !world.isRemote && heldStack != null && heldStack.getItem() == Items.glass_bottle && event.action == Action.RIGHT_CLICK_AIR) {
@@ -1173,6 +1142,74 @@ public class ServerEventHandler {
 				}
 			}
 		}
+	}
+
+	private static boolean cauldronInteract(
+		PlayerInteractEvent event, ItemStack heldStack, EntityPlayer player, World world, int x, int y, int z,
+		Block oldBlock, int meta
+	) {
+        if (heldStack == null || !canUse(player, world, x, y, z) || !(oldBlock instanceof BlockCauldron)) {
+            return false;
+        }
+
+        Item item = heldStack.getItem();
+
+        if (ConfigBlocksItems.enableLavaCauldrons) {
+			if (item == Items.bucket && oldBlock == ModBlocks.LAVA_CAULDRON.get()) {
+				event.setResult(Result.DENY);
+				player.swingItem();
+				world.setBlock(x, y, z, Blocks.cauldron);
+
+				if (ConfigSounds.fluidInteract) {
+					world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bucket.empty_lava", 1, 1);
+				}
+
+				convertHeldItem(player, 1, new ItemStack(Items.lava_bucket));
+
+				return true;
+			}
+
+			if (item == Items.lava_bucket && meta == 0) {
+				event.setResult(Result.DENY);
+				player.swingItem();
+				world.setBlock(x, y, z, ModBlocks.LAVA_CAULDRON.get());
+
+				if (ConfigSounds.fluidInteract) {
+					world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bucket.fill_lava", 1, 1);
+				}
+
+				convertHeldItem(player, 1, new ItemStack(Items.bucket));
+
+				return true;
+			}
+        }
+
+		if (item == Items.water_bucket && meta < 3) {
+			if (ConfigSounds.fluidInteract) {
+				world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bucket.fill", 1, 1);
+			}
+
+			return true;
+		} else if (item == Items.bucket && meta == 3) {
+			convertHeldItem(player, 1, new ItemStack(Items.water_bucket));
+			world.setBlockMetadataWithNotify(x, y, z, 0, 3);
+
+			if (ConfigSounds.fluidInteract) {
+				world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bucket.empty", 1, 1);
+			}
+
+			return true;
+		} else if (item == Items.glass_bottle || (item == Items.potionitem && heldStack.getItemDamage() == 0 && !heldStack.hasTagCompound())) {
+			String fillOrEmpty = item == Items.glass_bottle && meta > 0 ? "fill" : "empty";
+
+			if (ConfigSounds.fluidInteract) {
+				world.playSoundEffect(x, y, z, Reference.MCAssetVer + ":item.bottle." + fillOrEmpty, 1, 1);
+			}
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean doMudConversion(World world, int x, int y, int z, EntityPlayer player, Block oldBlock, int meta, ItemStack heldStack) {
@@ -2203,6 +2240,30 @@ public class ServerEventHandler {
 		}
 		Vec3 vec31 = vec3.addVector((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
 		return worldIn.func_147447_a/*rayTraceBlocks*/(vec3, vec31, useLiquids, !useLiquids, false);
+	}
+
+	private static boolean convertHeldItem(EntityPlayer player, int decrementAmount, ItemStack result) {
+		ItemStack held = player.getHeldItem();
+
+		if (held == null || held.stackSize < decrementAmount) return false;
+
+		if (!player.capabilities.isCreativeMode) {
+			held.stackSize -= decrementAmount;
+
+			if (held.stackSize == 0) {
+				player.inventory.mainInventory[player.inventory.currentItem] = null;
+			}
+		}
+
+		if (result != null) {
+			ItemStack resultCopy = result.copy();
+
+			if (!player.inventory.addItemStackToInventory(resultCopy)) {
+				player.worldObj.spawnEntityInWorld(new EntityItem(player.worldObj, player.posX, player.posY + 0.5, player.posZ, resultCopy));
+			}
+		}
+
+		return true;
 	}
 
 

--- a/src/main/java/ganymedes01/etfuturum/core/proxy/ClientProxy.java
+++ b/src/main/java/ganymedes01/etfuturum/core/proxy/ClientProxy.java
@@ -42,6 +42,7 @@ import ganymedes01.etfuturum.client.renderer.entity.BeeRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.BrownMooshroomRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.ChestBoatRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.EndermiteRenderer;
+import ganymedes01.etfuturum.client.renderer.entity.FallingDripstoneRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.FoxRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.HuskRenderer;
 import ganymedes01.etfuturum.client.renderer.entity.LingeringEffectRenderer;
@@ -77,6 +78,7 @@ import ganymedes01.etfuturum.entities.EntityArmourStand;
 import ganymedes01.etfuturum.entities.EntityBee;
 import ganymedes01.etfuturum.entities.EntityBrownMooshroom;
 import ganymedes01.etfuturum.entities.EntityEndermite;
+import ganymedes01.etfuturum.entities.EntityFallingDripstone;
 import ganymedes01.etfuturum.entities.EntityFox;
 import ganymedes01.etfuturum.entities.EntityHusk;
 import ganymedes01.etfuturum.entities.EntityLingeringEffect;
@@ -219,9 +221,7 @@ public class ClientProxy extends CommonProxy {
 
 		RenderingRegistry.registerEntityRenderingHandler(EntityPig.class, new TechnobladeCrownRenderer());
 
-//      {
-//          RenderingRegistry.registerEntityRenderingHandler(EntityFallingDripstone.class, new FallingDripstoneRenderer());
-//      }
+		RenderingRegistry.registerEntityRenderingHandler(EntityFallingDripstone.class, new FallingDripstoneRenderer());
 
 		if (ConfigFunctions.enablePlayerSkinOverlay) {
 			TextureManager texManager = Minecraft.getMinecraft().renderEngine;

--- a/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
+++ b/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
@@ -20,7 +20,6 @@ import ganymedes01.etfuturum.client.gui.inventory.GuiSmithingTable;
 import ganymedes01.etfuturum.client.gui.inventory.GuiSmoker;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
 import ganymedes01.etfuturum.configuration.configs.ConfigEntities;
-import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
 import ganymedes01.etfuturum.configuration.configs.ConfigTweaks;
 import ganymedes01.etfuturum.configuration.configs.ConfigWorld;
@@ -270,7 +269,7 @@ public class CommonProxy implements IGuiHandler {
 			}
 		}
 
-		if (ConfigExperiments.enableDripstone) {
+		if (ConfigBlocksItems.enableDripstone) {
 			ModEntityList.registerEntity(EntityFallingDripstone.class, "falling_dripstone", 18, EtFuturum.instance, 64, 1, true);
 		}
 

--- a/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
+++ b/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
@@ -20,6 +20,7 @@ import ganymedes01.etfuturum.client.gui.inventory.GuiSmithingTable;
 import ganymedes01.etfuturum.client.gui.inventory.GuiSmoker;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
 import ganymedes01.etfuturum.configuration.configs.ConfigEntities;
+import ganymedes01.etfuturum.configuration.configs.ConfigExperiments;
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
 import ganymedes01.etfuturum.configuration.configs.ConfigTweaks;
 import ganymedes01.etfuturum.configuration.configs.ConfigWorld;
@@ -35,6 +36,7 @@ import ganymedes01.etfuturum.entities.EntityBee;
 import ganymedes01.etfuturum.entities.EntityBoostingFireworkRocket;
 import ganymedes01.etfuturum.entities.EntityBrownMooshroom;
 import ganymedes01.etfuturum.entities.EntityEndermite;
+import ganymedes01.etfuturum.entities.EntityFallingDripstone;
 import ganymedes01.etfuturum.entities.EntityFox;
 import ganymedes01.etfuturum.entities.EntityHusk;
 import ganymedes01.etfuturum.entities.EntityItemUninflammable;
@@ -268,9 +270,9 @@ public class CommonProxy implements IGuiHandler {
 			}
 		}
 
-//      {
-//          ModEntityList.registerEntity(EntityFallingDripstone.class, "falling_dripstone", 18, EtFuturum.instance, 64, 1, true);
-//      }
+		if (ConfigExperiments.enableDripstone) {
+			ModEntityList.registerEntity(EntityFallingDripstone.class, "falling_dripstone", 18, EtFuturum.instance, 64, 1, true);
+		}
 
 		if (ConfigBlocksItems.enableNewBoats) {
 			ModEntityList.registerEntity(EntityNewBoat.class, "new_boat", 13, EtFuturum.instance, 64, 1, true);

--- a/src/main/java/ganymedes01/etfuturum/entities/EntityFallingDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityFallingDripstone.java
@@ -6,6 +6,7 @@ import ganymedes01.etfuturum.blocks.BlockPointedDripstone;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -28,6 +29,7 @@ public class EntityFallingDripstone extends EntityFallingBlock implements IEntit
 	public EntityFallingDripstone(World world, double x, double y, double z, int meta, int count) {
 		super(world, x, y, z, ModBlocks.POINTED_DRIPSTONE.get(), meta);
 		this.count = count;
+		this.fallHurtAmount = Math.max(count, 6); // 1 HP per piece (min 6) per block fallen
 		// The entity is anchored to the topmost block and spans `count` blocks downward,
 		// so yOffset and size must be updated before setPosition recomputes the bounding box.
 		this.yOffset = count - 0.5F;
@@ -78,14 +80,21 @@ public class EntityFallingDripstone extends EntityFallingBlock implements IEntit
 	@Override
 	protected void fall(float distance) {
 		if (!this.hurtEntities) return;
-		int damage = MathHelper.ceiling_float_int(distance - 1.0F);
-		if (damage <= 0) return;
+		int blocks = MathHelper.ceiling_float_int(distance - 1.0F);
+		if (blocks <= 0) return;
 
-		float dmgAmount = Math.min(damage * this.fallHurtAmount, this.fallHurtMax);
-		@SuppressWarnings("unchecked")
+		float baseDmg = Math.min(blocks * this.fallHurtAmount, this.fallHurtMax);
 		List<Entity> entities = this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox);
 		for (Entity entity : entities) {
-			entity.attackEntityFrom(BlockPointedDripstone.STALACTITE_DAMAGE, dmgAmount);
+			float dmg = baseDmg;
+			if (entity instanceof EntityLivingBase) {
+				ItemStack helmet = ((EntityLivingBase) entity).getEquipmentInSlot(4);
+				if (helmet != null) {
+					dmg *= 0.75F; // helmet reduces damage by 1/4
+					helmet.damageItem(2, (EntityLivingBase) entity); // 2× durability cost
+				}
+			}
+			entity.attackEntityFrom(BlockPointedDripstone.STALACTITE_DAMAGE, dmg);
 		}
 	}
 
@@ -114,9 +123,9 @@ public class EntityFallingDripstone extends EntityFallingBlock implements IEntit
 	protected void readEntityFromNBT(NBTTagCompound tag) {
 		super.readEntityFromNBT(tag);
 		this.hurtEntities = tag.getBoolean("HurtEntities");
-		this.fallHurtAmount = tag.getFloat("FallHurtAmount");
 		this.fallHurtMax = tag.getInteger("FallHurtMax");
 		this.count = tag.getInteger("Count");
+		this.fallHurtAmount = Math.max(this.count, 6); // always derived from count
 		this.yOffset = count - 0.5F;
 		this.setSize(0.98F, this.count);
 	}

--- a/src/main/java/ganymedes01/etfuturum/entities/EntityFallingDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityFallingDripstone.java
@@ -1,122 +1,123 @@
 package ganymedes01.etfuturum.entities;
 
+import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockPointedDripstone;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.List;
 
-public class EntityFallingDripstone extends EntityFallingBlock {
+public class EntityFallingDripstone extends EntityFallingBlock implements IEntityAdditionalSpawnData {
 
-	private int fallHurtMax;
-	private float fallHurtAmount;
-	private boolean hurtEntities;
+	private int fallHurtMax = 40;
+	private float fallHurtAmount = 4.0F;
+	private boolean hurtEntities = true;
+	private int count = 1;
 
-	public EntityFallingDripstone(World p_i45318_1_) {
-		super(p_i45318_1_);
-		this.fallHurtMax = 40;
-		this.fallHurtAmount = 4.0F;
-		hurtEntities = true;
+	public EntityFallingDripstone(World world) {
+		super(world);
 	}
 
-	public EntityFallingDripstone(World p_i45318_1_, double p_i45318_2_, double p_i45318_4_, double p_i45318_6_) {
-		super(p_i45318_1_, p_i45318_2_, p_i45318_4_, p_i45318_6_, ModBlocks.POINTED_DRIPSTONE.get());
-		this.fallHurtMax = 40;
-		this.fallHurtAmount = 4.0F;
-		hurtEntities = true;
+	public EntityFallingDripstone(World world, double x, double y, double z, int meta, int count) {
+		super(world, x, y, z, ModBlocks.POINTED_DRIPSTONE.get(), meta);
+		this.count = count;
+		// The entity is anchored to the topmost block and spans `count` blocks downward,
+		// so yOffset and size must be updated before setPosition recomputes the bounding box.
+		this.yOffset = count - 0.5F;
+		this.setSize(0.98F, count);
+		this.setPosition(x, y, z);
+	}
+
+	public int getCount() {
+		return count;
 	}
 
 	@Override
 	public void onUpdate() {
-
-		Block block = ModBlocks.POINTED_DRIPSTONE.get();
-
 		this.prevPosX = this.posX;
 		this.prevPosY = this.posY;
 		this.prevPosZ = this.posZ;
 		++this.field_145812_b; // fallTime
-		this.motionY -= 0.03999999910593033D;
+		this.motionY -= 0.04D;
 		this.moveEntity(this.motionX, this.motionY, this.motionZ);
-		this.motionX *= 0.9800000190734863D;
-		this.motionY *= 0.9800000190734863D;
-		this.motionZ *= 0.9800000190734863D;
+		this.motionX *= 0.98D;
+		this.motionY *= 0.98D;
+		this.motionZ *= 0.98D;
 
-		int i = MathHelper.floor_double(this.posX);
-		int j = MathHelper.floor_double(this.posY);
-		int k = MathHelper.floor_double(this.posZ);
-		if (this.field_145812_b == 1) { // fallTime
-			field_145814_a/*metadata*/ = worldObj.getBlockMetadata(i, j, k);
+		if (this.worldObj.isRemote) return;
+
+		int x = MathHelper.floor_double(this.posX);
+		int y = MathHelper.floor_double(this.posY);
+		int z = MathHelper.floor_double(this.posZ);
+
+		if (this.onGround) {
+			this.motionX *= 0.7D;
+			this.motionZ *= 0.7D;
+			this.motionY *= -0.5D;
+			dropItems();
+			this.setDead();
+		} else if ((this.field_145812_b > 100 && (y < 1 || y > 256)) || this.field_145812_b > 600) {
+			dropItems();
+			this.setDead();
 		}
+	}
 
-		if (!this.worldObj.isRemote) {
-
-			if (this.field_145812_b == 1) { // fallTime
-				if (this.worldObj.getBlock(i, j, k) != block) {
-					this.setDead();
-					return;
-				}
-
-				this.worldObj.setBlockToAir(i, j, k);
-			}
-
-			if (this.onGround && worldObj.getBlock(i, j - 1, k) != block) {
-				this.motionX *= 0.699999988079071D;
-				this.motionZ *= 0.699999988079071D;
-				this.motionY *= -0.5D;
-				this.setDead();
-
-				if (this.field_145813_c) { // shouldDropItem
-					this.entityDropItem(new ItemStack(block, 1, block.damageDropped(this.field_145814_a/*metadata*/)), 0.0F);
-				}
-			} else if (this.field_145812_b/*fallTime*/ > 100 && !this.worldObj.isRemote && (j < 1 || j > 256) || this.field_145812_b/*fallTime*/ > 600) {
-				if (this.field_145813_c) { // shouldDropItem
-					this.entityDropItem(new ItemStack(block, 1, block.damageDropped(this.field_145814_a/*metadata*/)), 0.0F);
-				}
-
-				this.setDead();
-			}
-		}
+	private void dropItems() {
+		if (!this.field_145813_c) return; // shouldDropItem
+		Block block = ModBlocks.POINTED_DRIPSTONE.get();
+		this.entityDropItem(new ItemStack(block, this.count, block.damageDropped(this.field_145814_a)), 0.5F);
 	}
 
 	@Override
 	protected void fall(float distance) {
-		if (this.hurtEntities) {
-			int i = MathHelper.ceiling_float_int(distance - 1.0F);
+		if (!this.hurtEntities) return;
+		int damage = MathHelper.ceiling_float_int(distance - 1.0F);
+		if (damage <= 0) return;
 
-			if (i > 0) {
-				ArrayList<Entity> arraylist = new ArrayList<>(this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox));
-				DamageSource damagesource = BlockPointedDripstone.STALACTITE_DAMAGE;
-				Iterator<Entity> iterator = arraylist.iterator();
-
-				while (iterator.hasNext()) {
-					Entity entity = iterator.next();
-					entity.attackEntityFrom(damagesource, (float) Math.min(MathHelper.floor_float((float) i * this.fallHurtAmount), this.fallHurtMax));
-				}
-			}
+		float dmgAmount = Math.min(damage * this.fallHurtAmount, this.fallHurtMax);
+		@SuppressWarnings("unchecked")
+		List<Entity> entities = this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox);
+		for (Entity entity : entities) {
+			entity.attackEntityFrom(BlockPointedDripstone.STALACTITE_DAMAGE, dmgAmount);
 		}
 	}
 
 	@Override
-	protected void writeEntityToNBT(NBTTagCompound tagCompound) {
-		super.writeEntityToNBT(tagCompound);
-		tagCompound.setBoolean("HurtEntities", this.hurtEntities);
-		tagCompound.setFloat("FallHurtAmount", this.fallHurtAmount);
-		tagCompound.setInteger("FallHurtMax", this.fallHurtMax);
+	public void writeSpawnData(ByteBuf buf) {
+		buf.writeInt(this.count);
 	}
 
 	@Override
-	protected void readEntityFromNBT(NBTTagCompound tagCompund) {
-		super.readEntityFromNBT(tagCompund);
-		this.hurtEntities = tagCompund.getBoolean("HurtEntities");
-		this.fallHurtAmount = tagCompund.getFloat("FallHurtAmount");
-		this.fallHurtMax = tagCompund.getInteger("FallHurtMax");
+	public void readSpawnData(ByteBuf buf) {
+		this.count = buf.readInt();
+		this.yOffset = count - 0.5F;
+		this.setSize(0.98F, this.count);
+	}
+
+	@Override
+	protected void writeEntityToNBT(NBTTagCompound tag) {
+		super.writeEntityToNBT(tag);
+		tag.setBoolean("HurtEntities", this.hurtEntities);
+		tag.setFloat("FallHurtAmount", this.fallHurtAmount);
+		tag.setInteger("FallHurtMax", this.fallHurtMax);
+		tag.setInteger("Count", this.count);
+	}
+
+	@Override
+	protected void readEntityFromNBT(NBTTagCompound tag) {
+		super.readEntityFromNBT(tag);
+		this.hurtEntities = tag.getBoolean("HurtEntities");
+		this.fallHurtAmount = tag.getFloat("FallHurtAmount");
+		this.fallHurtMax = tag.getInteger("FallHurtMax");
+		this.count = tag.getInteger("Count");
+		this.yOffset = count - 0.5F;
+		this.setSize(0.98F, this.count);
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
@@ -727,6 +727,10 @@ public class ModRecipes {
 		GameRegistry.addRecipe(new RecipeDuplicatePattern());
 		GameRegistry.addRecipe(new RecipeAddPattern());
 
+		if (ConfigBlocksItems.enableDripstone) {
+			addShapedRecipe(new ItemStack(ModBlocks.DRIPSTONE_BLOCK.get()), "xx", "xx", 'x', new ItemStack(ModBlocks.POINTED_DRIPSTONE.get()));
+		}
+
 		addShapedRecipe(ModItems.WOODEN_ARMORSTAND.newItemStack(), "xxx", " x ", "xyx", 'x', "stickWood", 'y', new ItemStack(Blocks.stone_slab));
 
 		addShapedRecipe(ModItems.RABBIT_STEW.newItemStack(), " R ", "CPM", " B ", 'R', ModItems.RABBIT_COOKED.newItemStack(), 'C', Items.carrot, 'P', Items.baked_potato, 'M', Blocks.brown_mushroom, 'B', "bowlWood");

--- a/src/main/java/ganymedes01/etfuturum/world/EtFuturumWorldGenerator.java
+++ b/src/main/java/ganymedes01/etfuturum/world/EtFuturumWorldGenerator.java
@@ -15,6 +15,7 @@ import ganymedes01.etfuturum.world.generate.decorate.WorldGenCaveVines;
 import ganymedes01.etfuturum.world.generate.decorate.WorldGenCherryTrees;
 import ganymedes01.etfuturum.world.generate.decorate.WorldGenGlowLichen;
 import ganymedes01.etfuturum.world.generate.decorate.WorldGenPinkPetals;
+import ganymedes01.etfuturum.world.generate.feature.WorldGenDripstone;
 import ganymedes01.etfuturum.world.generate.feature.WorldGenFossil;
 import ganymedes01.etfuturum.world.generate.feature.WorldGenGeode;
 import ganymedes01.etfuturum.world.structure.OceanMonument;
@@ -71,6 +72,7 @@ public class EtFuturumWorldGenerator implements IWorldGenerator {
 	protected WorldGenerator glowLichenGen;
 	protected WorldGenerator caveVineGen;
 	protected WorldGenerator mudGen;
+	protected IWorldGenerator dripstoneGen;
 
 	private List<BiomeGenBase> fossilBiomes;
 	private List<BiomeGenBase> berryBushBiomes;
@@ -183,6 +185,10 @@ public class EtFuturumWorldGenerator implements IWorldGenerator {
 			}
 
 			mudBiomes = Lists.newArrayList(BiomeDictionary.getBiomesForType(Type.SWAMP));
+		}
+
+		if (ModBlocks.DRIPSTONE_BLOCK.isEnabled() && ConfigWorld.dripstoneWorldgen) {
+			dripstoneGen = new WorldGenDripstone();
 		}
 	}
 
@@ -301,6 +307,10 @@ public class EtFuturumWorldGenerator implements IWorldGenerator {
 				if (y > 0 && mudBiomes.contains(world.getBiomeGenForCoords(x, z))) {
 					mudGen.generate(world, rand, x, world.getTopSolidOrLiquidBlock(x, z), z);
 				}
+			}
+
+			if (dripstoneGen != null) {
+				dripstoneGen.generate(rand, chunkX, chunkZ, world, chunkGenerator, chunkProvider);
 			}
 
 			if (fossilGen != null && rand.nextInt(64) == 0 && ArrayUtils.contains(ConfigWorld.fossilDimensionBlacklist, world.provider.dimensionId) == ConfigWorld.fossilDimensionBlacklistAsWhitelist) {

--- a/src/main/java/ganymedes01/etfuturum/world/generate/feature/WorldGenDripstone.java
+++ b/src/main/java/ganymedes01/etfuturum/world/generate/feature/WorldGenDripstone.java
@@ -1,0 +1,102 @@
+package ganymedes01.etfuturum.world.generate.feature;
+
+import java.util.Random;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.IChunkProvider;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.gtnewhorizon.gtnhlib.noise.NoiseSampler;
+import com.gtnewhorizon.gtnhlib.noise.NormalizedSampler;
+import com.gtnewhorizon.gtnhlib.noise.OctavesSampler;
+import com.gtnewhorizon.gtnhlib.noise.ScaledSampler;
+import com.gtnewhorizon.gtnhlib.util.StdLCG;
+import cpw.mods.fml.common.IWorldGenerator;
+import ganymedes01.etfuturum.ModBlocks;
+import ganymedes01.etfuturum.blocks.BlockPointedDripstone;
+import ganymedes01.etfuturum.configuration.configs.ConfigWorld;
+
+public class WorldGenDripstone implements IWorldGenerator {
+
+    /// We don't want to generate dripstone too close to the surface
+    private static final int MAX_HEIGHT = 16;
+    private static final double NOISE_THRESHOLD = 0.6;
+    private static final double DRIPSTONE_THRESHOLD = 0.65;
+
+    private final StdLCG rand = new StdLCG();
+
+    @Override
+    public void generate(
+        Random random, int chunkX, int chunkZ, World world, IChunkProvider chunkGenerator,
+        IChunkProvider chunkProvider
+    ) {
+        rand.setSeed(world.getSeed());
+        NoiseSampler humidity = new ScaledSampler(new NormalizedSampler(new OctavesSampler(rand, 6)), 0.02);
+
+        int wX = chunkX << 4;
+        int wZ = chunkZ << 4;
+
+        BlockPointedDripstone pointed = (BlockPointedDripstone) ModBlocks.POINTED_DRIPSTONE.get();
+
+        for (int rZ = 0; rZ < 16; rZ++) {
+            for (int rX = 0; rX < 16; rX++) {
+                int x = wX + rX + 8;
+                int z = wZ + rZ + 8;
+
+                BiomeGenBase biome = world.getBiomeGenForCoords(x, z);
+
+                boolean validBiome = biome.rootHeight >= 0.5 || biome.temperature >= 0.5 && biome.temperature <= 1.5 && biome.rainfall >= 0.5;
+
+                // We only want to generate in mountainy or humid biomes
+                if (!validBiome) continue;
+
+                int start = (ConfigWorld.deepslateGenerationMode != -1 ? ConfigWorld.deepslateMaxY : 10) + random.nextInt(8) - 4;
+
+                for (int y = start; y < world.getHeightValue(x, z) - MAX_HEIGHT; y++) {
+                    if (humidity.sample(x, y, z) < NOISE_THRESHOLD) continue;
+
+                    if (world.getBlock(x, y, z) != Blocks.stone) continue;
+
+                    int surroundingAir = 0;
+
+                    for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+                        if (world.isAirBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ)) {
+                            surroundingAir |= dir.flag;
+                        }
+                    }
+
+                    if (surroundingAir == 0) continue;
+
+                    world.setBlock(x, y, z, ModBlocks.DRIPSTONE_BLOCK.get(), 0, 2);
+
+                    if ((surroundingAir & ForgeDirection.UP.flag) != 0) {
+                        int height = (int) ((humidity.sample(x, y + 1, z) - NOISE_THRESHOLD) / 0.05);
+
+                        for (int y2 = 0; y2 < height; y2++) {
+                            world.setBlock(x, y + 1 + y2, z, pointed, pointed.up.getMetaPrimitive(true, 0), 2);
+                        }
+
+                        for (int y2 = 0; y2 < height; y2++) {
+                            pointed.onNeighborBlockChange(world, x, y + 1 + y2, z, pointed);
+                        }
+                    }
+
+                    if ((surroundingAir & ForgeDirection.DOWN.flag) != 0) {
+                        int height = (int) ((humidity.sample(x, y - 1, z) - NOISE_THRESHOLD) / 0.05);
+
+                        for (int y2 = 0; y2 < height; y2++) {
+                            world.setBlock(x, y - 1 - y2, z, pointed, pointed.up.getMetaPrimitive(false, 0), 2);
+                        }
+
+                        for (int y2 = 0; y2 < height; y2++) {
+                            pointed.onNeighborBlockChange(world, x, y - 1 - y2, z, pointed);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Dripstone was partially implemented, but most of its mechanics weren't finished. This should make it almost 100% identical to modern dripstone. The only quirk that I know of is that placing/removing dripstone updates each block independently. It's very obvious, but I couldn't figure out the cause - it seems like it's render pipeline related, so I left it alone.

depends on: https://github.com/GTNewHorizons/GTNHLib/pull/425 and https://github.com/GTNewHorizons/GTNHLib/pull/428

I can remove the dep on [GTNewHorizons/GTNHLib#425](https://github.com/GTNewHorizons/GTNHLib/pull/425) easily if someone wants to review this PR before that one. The second dep is trivial.

<img width="1920" height="1025" alt="2026-07-13_16 09 44" src="https://github.com/user-attachments/assets/99a33abc-13a6-45cd-9c83-101a2a56d414" />

<img width="1920" height="1025" alt="2026-07-14_17 06 07" src="https://github.com/user-attachments/assets/ba6d7ead-e729-4c20-a0aa-b9dedf66e144" />
<img width="1920" height="1025" alt="2026-07-14_17 11 17" src="https://github.com/user-attachments/assets/e7ca381b-141b-48f6-ad4c-cea909aab866" />
<img width="1920" height="1025" alt="2026-07-15_11 19 16" src="https://github.com/user-attachments/assets/f9ff3233-a0f5-4190-a2d7-511197c2f391" />

<img width="1920" height="1025" alt="2026-07-14_20 47 55" src="https://github.com/user-attachments/assets/3af2e1bc-7bdb-4a52-b18a-323badb30342" />
<img width="1920" height="1025" alt="2026-07-14_23 26 06" src="https://github.com/user-attachments/assets/b514c408-3e10-405b-bed2-ec8bfc3830f6" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
