### PR TITLE
Backport blocklight + nightvision color and gradients

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
+++ b/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
@@ -1,0 +1,142 @@
+package ganymedes01.etfuturum.client;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldProviderEnd;
+import net.minecraft.world.WorldProviderHell;
+
+import java.lang.ref.WeakReference;
+
+public final class ModernLightmap {
+
+	public static final float BLOCK_FACTOR = 1.4F;
+
+	public static final float FLICKER_FACTOR = 0.1F;
+
+	public static final float BIAS = 0.96F;
+
+	public static final float[] OVERWORLD_AMBIENT = {10.0F / 255.0F, 10.0F / 255.0F, 10.0F / 255.0F};
+
+	public static final float[] NETHER_AMBIENT = {48.0F / 255.0F, 40.0F / 255.0F, 33.0F / 255.0F};
+
+	public static final float[] END_AMBIENT = {63.0F / 255.0F, 71.0F / 255.0F, 63.0F / 255.0F};
+
+	public static final float[] NIGHT_VISION = {153.0F / 255.0F, 153.0F / 255.0F, 153.0F / 255.0F};
+
+	private static final float[] BLOCK_TINT = {1.0f, 216.0F / 255.0F, 140.0F / 255.0F};
+
+	public static final float[][] BLOCK_TINT_CURVE = {
+			generateTintCurve(BLOCK_TINT[0]), generateTintCurve(BLOCK_TINT[1]), generateTintCurve(BLOCK_TINT[2])
+	};
+
+	private static final float[] OVERWORLD_TABLE = generateTable(0.0F);
+
+	private static final float[] NETHER_TABLE = generateTable(0.1F);
+
+	private static WeakReference<WorldProvider> cachedProvider = new WeakReference<>(null);
+
+	private static float[] cachedAmbient;
+
+	private static boolean cachedModernCounterpart;
+
+	private ModernLightmap() {
+	}
+
+	public static float nightVisionBrightness(EntityPlayer player, float partialTicks) {
+		PotionEffect effect = player == null ? null : player.getActivePotionEffect(Potion.nightVision);
+		if (effect == null) {
+			return 0.0F;
+		}
+		int duration = effect.getDuration();
+		return duration > 200 ? 1.0F : 0.7F + MathHelper.sin((duration - partialTicks) * (float) Math.PI * 0.2F) * 0.3F;
+	}
+
+	public static float floor(float ambient, int channel, float nightVisionBrightness) {
+		return Math.max(ambient, NIGHT_VISION[channel] * nightVisionBrightness);
+	}
+
+	/**
+	 * False for a modded dimension whose brightness table matches nothing we know how to rebuild;
+	 * every modern lightmap change stays off there so the dimension keeps the look its mod tuned.
+	 */
+	public static boolean hasModernCounterpart(WorldProvider provider) {
+		resolve(provider);
+		return cachedModernCounterpart;
+	}
+
+	public static float[] ambientColor(WorldProvider provider) {
+		resolve(provider);
+		return cachedAmbient;
+	}
+
+	private static void resolve(WorldProvider provider) {
+		if (cachedProvider.get() == provider) {
+			return;
+		}
+		cachedProvider = new WeakReference<>(provider);
+		cachedAmbient = computeAmbientColor(provider);
+		cachedModernCounterpart = provider.dimensionId == 1 || cachedAmbient != null;
+	}
+
+	private static float[] computeAmbientColor(WorldProvider provider) {
+		switch (provider.dimensionId) {
+			case 0:
+				return OVERWORLD_AMBIENT;
+			case -1:
+				return NETHER_AMBIENT;
+			case 1:
+				return null; // The End writes its own floor in the dimensionId == 1 branch.
+			default:
+				break;
+		}
+		if (provider instanceof WorldProviderHell) {
+			return NETHER_AMBIENT;
+		}
+		if (provider instanceof WorldProviderEnd) {
+			return END_AMBIENT;
+		}
+		if (matchesTable(provider, OVERWORLD_TABLE)) {
+			return OVERWORLD_AMBIENT;
+		}
+		return matchesTable(provider, NETHER_TABLE) ? NETHER_AMBIENT : null;
+	}
+
+	private static boolean matchesTable(WorldProvider provider, float[] reference) {
+		float[] table = provider.lightBrightnessTable;
+		if (table == null || table.length != reference.length) {
+			return false;
+		}
+		for (int i = 0; i < reference.length; i++) {
+			if (table[i] != reference[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static float[] generateTable(float ambientLight) {
+		float[] table = new float[16];
+		for (int i = 0; i <= 15; i++) {
+			float f1 = 1.0F - (float) i / 15.0F;
+			table[i] = (1.0F - f1) / (f1 * 3.0F + 1.0F) * (1.0F - ambientLight) + ambientLight;
+		}
+		return table;
+	}
+
+	private static float[] generateTintCurve(float tint) {
+		float[] curve = new float[16];
+		for (int i = 0; i <= 15; i++) {
+			float level = i / 15.0F;
+			float mix = 0.9F * (2.0F * level - 1.0F) * (2.0F * level - 1.0F);
+			curve[i] = tint + (1.0F - tint) * mix;
+		}
+		return curve;
+	}
+
+	public static float ambientScale(float ambientLight) {
+		return 1.0F / (1.0F - Math.min(ambientLight, 0.99F));
+	}
+}

--- a/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
+++ b/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
@@ -18,11 +18,11 @@ public final class ModernLightmap {
 
 	public static final float BIAS = 0.96F;
 
-	public static final float[] OVERWORLD_AMBIENT = {10.0F / 255.0F, 10.0F / 255.0F, 10.0F / 255.0F};
+	private static final float[] OVERWORLD_AMBIENT = {10.0F / 255.0F, 10.0F / 255.0F, 10.0F / 255.0F};
 
-	public static final float[] NETHER_AMBIENT = {48.0F / 255.0F, 40.0F / 255.0F, 33.0F / 255.0F};
+	private static final float[] NETHER_AMBIENT = {48.0F / 255.0F, 40.0F / 255.0F, 33.0F / 255.0F};
 
-	public static final float[] END_AMBIENT = {63.0F / 255.0F, 71.0F / 255.0F, 63.0F / 255.0F};
+	private static final float[] END_AMBIENT = {63.0F / 255.0F, 71.0F / 255.0F, 63.0F / 255.0F};
 
 	public static final float[] NIGHT_VISION = {153.0F / 255.0F, 153.0F / 255.0F, 153.0F / 255.0F};
 
@@ -36,7 +36,11 @@ public final class ModernLightmap {
 
 	private static final float[] NETHER_TABLE = generateTable(0.1F);
 
+	private static final float NO_AMBIENT_LIGHT = -1.0F;
+
 	private static WeakReference<WorldProvider> cachedProvider = new WeakReference<>(null);
+
+	private static float cachedAmbientLight = NO_AMBIENT_LIGHT;
 
 	private static float[] cachedAmbient;
 
@@ -58,6 +62,10 @@ public final class ModernLightmap {
 		return Math.max(ambient, NIGHT_VISION[channel] * nightVisionBrightness);
 	}
 
+	public static float endAmbient(int channel) {
+		return END_AMBIENT[channel];
+	}
+
 	/**
 	 * False for a modded dimension whose brightness table matches nothing we know how to rebuild;
 	 * every modern lightmap change stays off there so the dimension keeps the look its mod tuned.
@@ -67,18 +75,30 @@ public final class ModernLightmap {
 		return cachedModernCounterpart;
 	}
 
-	public static float[] ambientColor(WorldProvider provider) {
+	public static boolean hasAmbientColor(WorldProvider provider) {
 		resolve(provider);
-		return cachedAmbient;
+		return cachedAmbient != null;
+	}
+
+	public static float ambientColor(WorldProvider provider, int channel) {
+		resolve(provider);
+		return cachedAmbient == null ? 0.0F : cachedAmbient[channel];
 	}
 
 	private static void resolve(WorldProvider provider) {
-		if (cachedProvider.get() == provider) {
+		float ambientLight = ambientLight(provider);
+		if (cachedProvider.get() == provider && cachedAmbientLight == ambientLight) {
 			return;
 		}
 		cachedProvider = new WeakReference<>(provider);
+		cachedAmbientLight = ambientLight;
 		cachedAmbient = computeAmbientColor(provider);
 		cachedModernCounterpart = provider.dimensionId == 1 || cachedAmbient != null;
+	}
+
+	private static float ambientLight(WorldProvider provider) {
+		float[] table = provider.lightBrightnessTable;
+		return table == null || table.length == 0 ? NO_AMBIENT_LIGHT : table[0];
 	}
 
 	private static float[] computeAmbientColor(WorldProvider provider) {

--- a/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
+++ b/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
@@ -86,14 +86,14 @@ public final class ModernLightmap {
 			case 0:
 				return OVERWORLD_AMBIENT;
 			case -1:
-				return NETHER_AMBIENT;
+				return netherAmbient(provider);
 			case 1:
 				return null; // The End writes its own floor in the dimensionId == 1 branch.
 			default:
 				break;
 		}
 		if (provider instanceof WorldProviderHell) {
-			return NETHER_AMBIENT;
+			return netherAmbient(provider);
 		}
 		if (provider instanceof WorldProviderEnd) {
 			return END_AMBIENT;
@@ -102,6 +102,11 @@ public final class ModernLightmap {
 			return OVERWORLD_AMBIENT;
 		}
 		return matchesTable(provider, NETHER_TABLE) ? NETHER_AMBIENT : null;
+	}
+
+	private static float[] netherAmbient(WorldProvider provider) {
+		float[] table = provider.lightBrightnessTable;
+		return table == null || table.length == 0 || table[0] <= 0.0F ? null : NETHER_AMBIENT;
 	}
 
 	private static boolean matchesTable(WorldProvider provider, float[] reference) {

--- a/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
+++ b/src/main/java/ganymedes01/etfuturum/client/ModernLightmap.java
@@ -2,8 +2,6 @@ package ganymedes01.etfuturum.client;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
-import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldProviderEnd;
 import net.minecraft.world.WorldProviderHell;
@@ -49,13 +47,8 @@ public final class ModernLightmap {
 	private ModernLightmap() {
 	}
 
-	public static float nightVisionBrightness(EntityPlayer player, float partialTicks) {
-		PotionEffect effect = player == null ? null : player.getActivePotionEffect(Potion.nightVision);
-		if (effect == null) {
-			return 0.0F;
-		}
-		int duration = effect.getDuration();
-		return duration > 200 ? 1.0F : 0.7F + MathHelper.sin((duration - partialTicks) * (float) Math.PI * 0.2F) * 0.3F;
+	public static boolean hasNightVision(EntityPlayer player) {
+		return player != null && player.isPotionActive(Potion.nightVision);
 	}
 
 	public static float floor(float ambient, int channel, float nightVisionBrightness) {

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
@@ -28,6 +28,8 @@ public class ConfigWorld extends ConfigBase {
 	public static boolean endFlashes;
 	public static boolean modernEndAmbientColor;
 	public static boolean modernLightmapGamma;
+	public static boolean modernBlockLightTint;
+	public static boolean modernNightVision;
 	public static boolean enableAirDebris;
 	public static int debrisMax = 3;
 	public static int maxNetherGoldPerCluster;
@@ -98,8 +100,10 @@ public class ConfigWorld extends ConfigBase {
 		enableDmgIndicator = getBoolean("enableDmgIndicator", catClient, true, "Heart Damage Indicator");
 
 		endFlashes = getBoolean("endFlashes", catClient, true, "Allow The End dimension to have periodic flashes of light in the sky");
-		modernEndAmbientColor = getBoolean("modernEndAmbientColor", catClient, true, "Tint The End's ambient lighting to match modern Minecraft.");
+		modernEndAmbientColor = getBoolean("modernEndAmbientColor", catClient, true, "Rebuild The End's lightmap to match modern Minecraft.");
 		modernLightmapGamma = getBoolean("modernLightmapGamma", catClient, true, "Replaces the vanilla brightness-slider curve with the modern hue and saturation preserving one.");
+		modernBlockLightTint = getBoolean("modernBlockLightTint", catClient, true, "Adjust block light color and gradient to match modern Minecraft.");
+		modernNightVision = getBoolean("modernNightVision", catClient, true, "Adjust night vision to match modern Minecraft.");
 		enableAirDebris = getBoolean("enableAirDebris", catGeneration, false, "Can ancient debris generate next to air?");
 		maxStonesPerCluster = getInt("maxStonesPerCluster", catGeneration, 32, 0, 64, "Max vein size for Granite/Andesite/Diorite blocks in a cluster");
 		smallDebrisMax = getInt("smallDebrisMax", catGeneration, 2, 0, 64, "The max vein size for the first, typically smaller debris veins which generate from Y 8 to 119");

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -140,7 +140,8 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 			mixins.add("randomtickspeed.MixinGameRules");
 		}
 
-		if ((ConfigWorld.endFlashes || ConfigWorld.modernEndAmbientColor) && side == MixinEnvironment.Side.CLIENT) {
+		if ((ConfigWorld.endFlashes || ConfigWorld.modernEndAmbientColor || ConfigWorld.modernBlockLightTint)
+				&& side == MixinEnvironment.Side.CLIENT) {
 			mixins.add("endflashes.client.MixinEntityRenderer");
 		}
 
@@ -150,6 +151,11 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 
 		if (ConfigWorld.modernLightmapGamma && side == MixinEnvironment.Side.CLIENT) {
 			mixins.add("modernlightmap.client.MixinEntityRenderer");
+		}
+
+		if ((ConfigWorld.modernBlockLightTint || ConfigWorld.modernNightVision)
+				&& side == MixinEnvironment.Side.CLIENT) {
+			mixins.add("modernblocklight.client.MixinEntityRenderer");
 		}
 
 		if (ConfigMixins.creativeFlightSpeedModifier > 1 || ConfigTweaks.creativeFlightVerticalModifier > 1) {

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
@@ -94,9 +94,9 @@ public class MixinEntityRenderer {
 		float nightVision = ConfigWorld.modernNightVision
 				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
 				: 0.0F;
-		this.etfu$floorRed = ModernLightmap.floor(ModernLightmap.END_AMBIENT[0], 0, nightVision);
-		this.etfu$floorGreen = ModernLightmap.floor(ModernLightmap.END_AMBIENT[1], 1, nightVision);
-		this.etfu$floorBlue = ModernLightmap.floor(ModernLightmap.END_AMBIENT[2], 2, nightVision);
+		this.etfu$floorRed = ModernLightmap.floor(ModernLightmap.endAmbient(0), 0, nightVision);
+		this.etfu$floorGreen = ModernLightmap.floor(ModernLightmap.endAmbient(1), 1, nightVision);
+		this.etfu$floorBlue = ModernLightmap.floor(ModernLightmap.endAmbient(2), 2, nightVision);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.22F))

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
@@ -6,6 +6,7 @@ import ganymedes01.etfuturum.core.handlers.ClientEventHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -44,6 +45,11 @@ public class MixinEntityRenderer {
 
 	@Shadow
 	private float bossColorModifierPrev;
+
+	@Shadow
+	private float getNightVisionBrightness(EntityPlayer p_82830_1_, float p_82830_2_) {
+		return 0.0F;
+	}
 
 	@Unique
 	private float etfu$flashRed;
@@ -92,8 +98,9 @@ public class MixinEntityRenderer {
 		this.etfu$flashBlue = intensity * FLASH_B;
 
 		float nightVision = ConfigWorld.modernNightVision
-				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
-				: 0.0F;
+				&& ModernLightmap.hasNightVision(this.mc.thePlayer)
+						? this.getNightVisionBrightness(this.mc.thePlayer, p_78472_1_)
+						: 0.0F;
 		this.etfu$floorRed = ModernLightmap.floor(ModernLightmap.endAmbient(0), 0, nightVision);
 		this.etfu$floorGreen = ModernLightmap.floor(ModernLightmap.endAmbient(1), 1, nightVision);
 		this.etfu$floorBlue = ModernLightmap.floor(ModernLightmap.endAmbient(2), 2, nightVision);

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/endflashes/client/MixinEntityRenderer.java
@@ -1,51 +1,149 @@
 package ganymedes01.etfuturum.mixins.early.endflashes.client;
 
-import com.llamalad7.mixinextras.sugar.Local;
+import ganymedes01.etfuturum.client.ModernLightmap;
 import ganymedes01.etfuturum.configuration.configs.ConfigWorld;
 import ganymedes01.etfuturum.core.handlers.ClientEventHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Brightens The End's lightmap while a flash is active and/or raise The End's red floor.
+ * Brightens The End's lightmap while a flash is active and/or moves The End's ambient floor onto
+ * the one modern Minecraft uses.
  */
 @Mixin(EntityRenderer.class)
 public class MixinEntityRenderer {
-
+	@Unique
 	private static final float FLASH_R = 172.0F / 255.0F;
+	@Unique
 	private static final float FLASH_G = 96.0F / 255.0F;
+	@Unique
 	private static final float FLASH_B = 205.0F / 255.0F;
 
-	private static final float FLOOR_R = 63.0F / 255.0F;
-	private static final float FLOOR_G = 71.0F / 255.0F;
-	private static final float FLOOR_B = 63.0F / 255.0F;
+	@Unique
+	private static final float MODERN_BLOCK_SCALE = 1.0F;
+	@Unique
+	private static final float LEGACY_BLOCK_SCALE = 1.4F / (1.5F * 0.96F);
+
+	@Unique
+	private static final float RESTORED_BLOCK_SCALE = 1.5F * 0.96F / 1.4F;
+
+	@Shadow
+	private Minecraft mc;
 
 	@Shadow
 	private float bossColorModifier;
 
-	private float etfu$endFlashBoost(float partialTicks) {
-		float intensity = ClientEventHandler.getEndFlashIntensity(partialTicks);
-		return this.bossColorModifier > 0.0F ? intensity / 3.0F : intensity;
+	@Shadow
+	private float bossColorModifierPrev;
+
+	@Unique
+	private float etfu$flashRed;
+
+	@Unique
+	private float etfu$flashGreen;
+
+	@Unique
+	private float etfu$flashBlue;
+
+	@Unique
+	private float etfu$darkeningRed;
+
+	@Unique
+	private float etfu$darkeningGreenBlue;
+
+	@Unique
+	private float etfu$floorRed;
+
+	@Unique
+	private float etfu$floorGreen;
+
+	@Unique
+	private float etfu$floorBlue;
+
+	@Inject(method = "updateLightmap", at = @At("HEAD"))
+	private void etfu$resolveEndLightmap(float p_78472_1_, CallbackInfo ci) {
+		WorldClient world = this.mc.theWorld;
+		if (world == null || world.provider.dimensionId != 1) {
+			return;
+		}
+
+		float intensity = ClientEventHandler.getEndFlashIntensity(p_78472_1_);
+		if (this.bossColorModifier > 0.0F) {
+			intensity /= 3.0F;
+			float blend = this.bossColorModifierPrev
+					+ (this.bossColorModifier - this.bossColorModifierPrev) * p_78472_1_;
+			this.etfu$darkeningRed = 1.0F - (1.0F - 0.7F) * blend;
+			this.etfu$darkeningGreenBlue = 1.0F - (1.0F - 0.6F) * blend;
+		} else {
+			this.etfu$darkeningRed = 1.0F;
+			this.etfu$darkeningGreenBlue = 1.0F;
+		}
+		this.etfu$flashRed = intensity * FLASH_R;
+		this.etfu$flashGreen = intensity * FLASH_G;
+		this.etfu$flashBlue = intensity * FLASH_B;
+
+		float nightVision = ConfigWorld.modernNightVision
+				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
+				: 0.0F;
+		this.etfu$floorRed = ModernLightmap.floor(ModernLightmap.END_AMBIENT[0], 0, nightVision);
+		this.etfu$floorGreen = ModernLightmap.floor(ModernLightmap.END_AMBIENT[1], 1, nightVision);
+		this.etfu$floorBlue = ModernLightmap.floor(ModernLightmap.END_AMBIENT[2], 2, nightVision);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.22F))
-	private float etfu$endFlashRed(float original, @Local(argsOnly = true) float partialTicks) {
-		float base = ConfigWorld.modernEndAmbientColor ? FLOOR_R : original;
-		return base + etfu$endFlashBoost(partialTicks) * FLASH_R;
+	private float etfu$endFloorRed(float original) {
+		return etfu$endFloor(original, this.etfu$floorRed, this.etfu$flashRed, this.etfu$darkeningRed);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.28F))
-	private float etfu$endFlashGreen(float original, @Local(argsOnly = true) float partialTicks) {
-		float base = ConfigWorld.modernEndAmbientColor ? FLOOR_G : original;
-		return base + etfu$endFlashBoost(partialTicks) * FLASH_G;
+	private float etfu$endFloorGreen(float original) {
+		return etfu$endFloor(original, this.etfu$floorGreen, this.etfu$flashGreen, this.etfu$darkeningGreenBlue);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.25F))
-	private float etfu$endFlashBlue(float original, @Local(argsOnly = true) float partialTicks) {
-		float base = ConfigWorld.modernEndAmbientColor ? FLOOR_B : original;
-		return base + etfu$endFlashBoost(partialTicks) * FLASH_B;
+	private float etfu$endFloorBlue(float original) {
+		return etfu$endFloor(original, this.etfu$floorBlue, this.etfu$flashBlue, this.etfu$darkeningGreenBlue);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.75F, ordinal = 0))
+	private float etfu$endBlockScaleRed(float original) {
+		return etfu$endBlockScale(original, this.etfu$darkeningRed);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.75F, ordinal = 1))
+	private float etfu$endBlockScaleGreen(float original) {
+		return etfu$endBlockScale(original, this.etfu$darkeningGreenBlue);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.75F, ordinal = 2))
+	private float etfu$endBlockScaleBlue(float original) {
+		return etfu$endBlockScale(original, this.etfu$darkeningGreenBlue);
+	}
+
+	@Unique
+	private float etfu$endFloor(float vanilla, float modern, float flash, float darkening) {
+		if (!ConfigWorld.modernEndAmbientColor) {
+			float floor = vanilla + flash;
+			return ConfigWorld.modernBlockLightTint ? floor * ModernLightmap.BIAS + 0.03F : floor;
+		}
+		float target = (modern + flash) * darkening;
+		return ConfigWorld.modernBlockLightTint ? target : (target - 0.03F) / ModernLightmap.BIAS;
+	}
+
+	@Unique
+	private float etfu$endBlockScale(float vanilla, float darkening) {
+		if (!ConfigWorld.modernEndAmbientColor) {
+			return ConfigWorld.modernBlockLightTint ? vanilla * RESTORED_BLOCK_SCALE : vanilla;
+		}
+		return (ConfigWorld.modernBlockLightTint ? MODERN_BLOCK_SCALE : LEGACY_BLOCK_SCALE) * darkening;
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
@@ -37,6 +37,9 @@ public class MixinEntityRenderer {
 	private Minecraft mc;
 
 	@Unique
+	private boolean etfu$counterpart;
+
+	@Unique
 	private boolean etfu$modernBlockLight;
 
 	@Unique
@@ -80,6 +83,7 @@ public class MixinEntityRenderer {
 		}
 		WorldProvider provider = world.provider;
 		boolean counterpart = ModernLightmap.hasModernCounterpart(provider);
+		this.etfu$counterpart = counterpart;
 		this.etfu$ambientColor = ModernLightmap.ambientColor(provider);
 		this.etfu$modernBlockLight = ConfigWorld.modernBlockLightTint && counterpart;
 		this.etfu$modernNightVision = ConfigWorld.modernNightVision && counterpart
@@ -94,18 +98,23 @@ public class MixinEntityRenderer {
 		this.etfu$legacyGreen = etfu$vanillaGreen(this.etfu$ambientTerm);
 		this.etfu$legacyBlue = etfu$vanillaBlue(this.etfu$ambientTerm);
 
-		float nightVision = ConfigWorld.modernNightVision
+		this.etfu$nightVisionBrightness = ConfigWorld.modernNightVision
 				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
 				: 0.0F;
+	}
 
-		// What the dimension's ambient light leaks into the sky and block terms, per channel.
-		float sun = world.getSunBrightness(1.0F);
-		float sky = offset * (world.lastLightningBolt > 0 ? 1.0F : sun * 0.95F + 0.05F);
-		float sunlit = sky * (sun * 0.65F + 0.35F);
-		this.etfu$floorRed = etfu$ambientFloor(counterpart, 0, nightVision, sunlit + this.etfu$ambientTerm);
-		this.etfu$floorGreen = etfu$ambientFloor(counterpart, 1, nightVision, sunlit);
-		this.etfu$floorBlue = etfu$ambientFloor(counterpart, 2, nightVision, sky);
-		this.etfu$nightVisionBrightness = nightVision;
+	@Inject(method = "updateLightmap", at = @At(value = "CONSTANT", args = "floatValue=0.96F", ordinal = 0))
+	private void etfu$resolveAmbientFloors(float p_78472_1_, CallbackInfo ci,
+										   @Local(name = "i") int i,
+										   @Local(name = "f2") float f2,
+										   @Local(name = "f5") float f5) {
+		if (i != 0) {
+			return;
+		}
+		float nightVision = this.etfu$nightVisionBrightness;
+		this.etfu$floorRed = etfu$ambientFloor(0, nightVision, f5 + this.etfu$ambientTerm);
+		this.etfu$floorGreen = etfu$ambientFloor(1, nightVision, f5);
+		this.etfu$floorBlue = etfu$ambientFloor(2, nightVision, f2);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.1F))
@@ -254,8 +263,8 @@ public class MixinEntityRenderer {
 	}
 
 	@Unique
-	private float etfu$ambientFloor(boolean counterpart, int channel, float nightVisionBrightness, float leak) {
-		if (!counterpart) {
+	private float etfu$ambientFloor(int channel, float nightVisionBrightness, float leak) {
+		if (!this.etfu$counterpart) {
 			return 0.03F;
 		}
 		float nightVision = this.etfu$modernNightVision

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
@@ -10,6 +10,8 @@ import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.potion.Potion;
 import net.minecraft.world.WorldProvider;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -51,6 +53,9 @@ public class MixinEntityRenderer {
 
 	@Unique
 	private float etfu$ambientTerm;
+
+	@Unique
+	private float etfu$nightVisionBrightness;
 
 	@Unique
 	private float etfu$legacyGreen;
@@ -100,6 +105,7 @@ public class MixinEntityRenderer {
 		this.etfu$floorRed = etfu$ambientFloor(counterpart, 0, nightVision, sunlit + this.etfu$ambientTerm);
 		this.etfu$floorGreen = etfu$ambientFloor(counterpart, 1, nightVision, sunlit);
 		this.etfu$floorBlue = etfu$ambientFloor(counterpart, 2, nightVision, sky);
+		this.etfu$nightVisionBrightness = nightVision;
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.1F))
@@ -216,6 +222,35 @@ public class MixinEntityRenderer {
 	@Unique
 	private float etfu$dropTrailingOffset(float original) {
 		return this.etfu$modernBlockLight ? 0.0F : original;
+	}
+
+	@Final
+    @Shadow
+	private int[] lightmapColors;
+
+	@Inject(method = "updateLightmap", at = @At(value = "FIELD",
+			opcode = Opcodes.GETFIELD,
+			target = "Lnet/minecraft/client/renderer/EntityRenderer;lightmapTexture:Lnet/minecraft/client/renderer/texture/DynamicTexture;"))
+	private void etfu$applyNightVisionBoostLast(float p_78472_1_, CallbackInfo ci) {
+		if (!this.etfu$modernNightVision || this.etfu$nightVisionBrightness <= 0.0F) {
+			return;
+		}
+		float nvRed = ModernLightmap.NIGHT_VISION[0] * this.etfu$nightVisionBrightness;
+		float nvGreen = ModernLightmap.NIGHT_VISION[1] * this.etfu$nightVisionBrightness;
+		float nvBlue = ModernLightmap.NIGHT_VISION[2] * this.etfu$nightVisionBrightness;
+
+		for (int i = 0; i < this.lightmapColors.length; i++) {
+			int color = this.lightmapColors[i];
+			int r = (color >> 16) & 0xFF;
+			int g = (color >> 8) & 0xFF;
+			int b = color & 0xFF;
+
+			r = Math.min(0xFF, (int) Math.max(r, nvRed * 255.0F));
+			g = Math.min(0xFF, (int) Math.max(g, nvGreen * 255.0F));
+			b = Math.min(0xFF, (int) Math.max(b, nvBlue * 255.0F));
+
+			this.lightmapColors[i] = (color & 0xFF000000) | (r << 16) | (g << 8) | b;
+		}
 	}
 
 	@Unique

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
@@ -46,7 +46,16 @@ public class MixinEntityRenderer {
 	private boolean etfu$modernNightVision;
 
 	@Unique
-	private float[] etfu$ambientColor;
+	private boolean etfu$hasAmbientColor;
+
+	@Unique
+	private float etfu$ambientRed;
+
+	@Unique
+	private float etfu$ambientGreen;
+
+	@Unique
+	private float etfu$ambientBlue;
 
 	@Unique
 	private float etfu$flickerFactor;
@@ -84,7 +93,10 @@ public class MixinEntityRenderer {
 		WorldProvider provider = world.provider;
 		boolean counterpart = ModernLightmap.hasModernCounterpart(provider);
 		this.etfu$counterpart = counterpart;
-		this.etfu$ambientColor = ModernLightmap.ambientColor(provider);
+		this.etfu$hasAmbientColor = ModernLightmap.hasAmbientColor(provider);
+		this.etfu$ambientRed = ModernLightmap.ambientColor(provider, 0);
+		this.etfu$ambientGreen = ModernLightmap.ambientColor(provider, 1);
+		this.etfu$ambientBlue = ModernLightmap.ambientColor(provider, 2);
 		this.etfu$modernBlockLight = ConfigWorld.modernBlockLightTint && counterpart;
 		this.etfu$modernNightVision = ConfigWorld.modernNightVision && counterpart
 				&& (provider.dimensionId != 1 || ConfigWorld.modernEndAmbientColor);
@@ -112,9 +124,9 @@ public class MixinEntityRenderer {
 			return;
 		}
 		float nightVision = this.etfu$nightVisionBrightness;
-		this.etfu$floorRed = etfu$ambientFloor(0, nightVision, f5 + this.etfu$ambientTerm);
-		this.etfu$floorGreen = etfu$ambientFloor(1, nightVision, f5);
-		this.etfu$floorBlue = etfu$ambientFloor(2, nightVision, f2);
+		this.etfu$floorRed = etfu$ambientFloor(this.etfu$ambientRed, 0, nightVision, f5 + this.etfu$ambientTerm);
+		this.etfu$floorGreen = etfu$ambientFloor(this.etfu$ambientGreen, 1, nightVision, f5);
+		this.etfu$floorBlue = etfu$ambientFloor(this.etfu$ambientBlue, 2, nightVision, f2);
 	}
 
 	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.1F))
@@ -212,7 +224,7 @@ public class MixinEntityRenderer {
 		float g = levelTerm * ModernLightmap.BLOCK_TINT_CURVE[1][level];
 		float b = levelTerm * ModernLightmap.BLOCK_TINT_CURVE[2][level];
 
-		if (this.etfu$ambientColor == null) {
+		if (!this.etfu$hasAmbientColor) {
 			g += this.etfu$legacyGreen;
 			b += this.etfu$legacyBlue;
 		}
@@ -263,7 +275,7 @@ public class MixinEntityRenderer {
 	}
 
 	@Unique
-	private float etfu$ambientFloor(int channel, float nightVisionBrightness, float leak) {
+	private float etfu$ambientFloor(float ambient, int channel, float nightVisionBrightness, float leak) {
 		if (!this.etfu$counterpart) {
 			return 0.03F;
 		}
@@ -271,9 +283,9 @@ public class MixinEntityRenderer {
 				? ModernLightmap.NIGHT_VISION[channel] * nightVisionBrightness
 				: 0.0F;
 		if (ConfigWorld.modernBlockLightTint) {
-			return this.etfu$ambientColor == null
-					? 0.03F
-					: Math.max(this.etfu$ambientColor[channel], nightVision) - leak;
+			return this.etfu$hasAmbientColor
+					? Math.max(ambient, nightVision) - leak
+					: 0.03F;
 		}
 		return Math.max(0.03F, (nightVision - 0.03F) / ModernLightmap.BIAS);
 	}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
 import net.minecraft.world.WorldProvider;
 import org.objectweb.asm.Opcodes;
@@ -35,6 +36,11 @@ public class MixinEntityRenderer {
 
 	@Shadow
 	private Minecraft mc;
+
+	@Shadow
+	private float getNightVisionBrightness(EntityPlayer p_82830_1_, float p_82830_2_) {
+		return 0.0F;
+	}
 
 	@Unique
 	private boolean etfu$counterpart;
@@ -111,8 +117,9 @@ public class MixinEntityRenderer {
 		this.etfu$legacyBlue = etfu$vanillaBlue(this.etfu$ambientTerm);
 
 		this.etfu$nightVisionBrightness = ConfigWorld.modernNightVision
-				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
-				: 0.0F;
+				&& ModernLightmap.hasNightVision(this.mc.thePlayer)
+						? this.getNightVisionBrightness(this.mc.thePlayer, p_78472_1_)
+						: 0.0F;
 	}
 
 	@Inject(method = "updateLightmap", at = @At(value = "CONSTANT", args = "floatValue=0.96F", ordinal = 0))

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernblocklight/client/MixinEntityRenderer.java
@@ -1,0 +1,246 @@
+package ganymedes01.etfuturum.mixins.early.modernblocklight.client;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+import ganymedes01.etfuturum.client.ModernLightmap;
+import ganymedes01.etfuturum.configuration.configs.ConfigWorld;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.potion.Potion;
+import net.minecraft.world.WorldProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Rebuilds block light the way modern Minecraft's lightmap shader does: modern's block factor,
+ * modern's flat tint with a parabolic white mix in place of vanilla's per-channel polynomials, and
+ * modern's ambient light color in place of vanilla's flat black floor.
+ */
+@Mixin(EntityRenderer.class)
+public class MixinEntityRenderer {
+
+	@Shadow
+	float torchFlickerX;
+
+	@Shadow
+	private Minecraft mc;
+
+	@Unique
+	private boolean etfu$modernBlockLight;
+
+	@Unique
+	private boolean etfu$modernNightVision;
+
+	@Unique
+	private float[] etfu$ambientColor;
+
+	@Unique
+	private float etfu$flickerFactor;
+
+	@Unique
+	private float etfu$blockFactor;
+
+	@Unique
+	private float etfu$ambientTerm;
+
+	@Unique
+	private float etfu$legacyGreen;
+
+	@Unique
+	private float etfu$legacyBlue;
+
+	@Unique
+	private float etfu$floorRed;
+
+	@Unique
+	private float etfu$floorGreen;
+
+	@Unique
+	private float etfu$floorBlue;
+
+	@Inject(method = "updateLightmap", at = @At("HEAD"))
+	private void etfu$resolveModernBlockLight(float p_78472_1_, CallbackInfo ci) {
+		WorldClient world = this.mc.theWorld;
+		if (world == null) {
+			return;
+		}
+		WorldProvider provider = world.provider;
+		boolean counterpart = ModernLightmap.hasModernCounterpart(provider);
+		this.etfu$ambientColor = ModernLightmap.ambientColor(provider);
+		this.etfu$modernBlockLight = ConfigWorld.modernBlockLightTint && counterpart;
+		this.etfu$modernNightVision = ConfigWorld.modernNightVision && counterpart
+				&& (provider.dimensionId != 1 || ConfigWorld.modernEndAmbientColor);
+
+		float offset = provider.lightBrightnessTable[0];
+		float scale = ModernLightmap.ambientScale(offset);
+		this.etfu$flickerFactor = ModernLightmap.FLICKER_FACTOR * scale;
+		this.etfu$blockFactor = ModernLightmap.BLOCK_FACTOR * scale;
+		this.etfu$ambientTerm = offset
+				* (this.torchFlickerX * ModernLightmap.FLICKER_FACTOR + ModernLightmap.BLOCK_FACTOR) * scale;
+		this.etfu$legacyGreen = etfu$vanillaGreen(this.etfu$ambientTerm);
+		this.etfu$legacyBlue = etfu$vanillaBlue(this.etfu$ambientTerm);
+
+		float nightVision = ConfigWorld.modernNightVision
+				? ModernLightmap.nightVisionBrightness(this.mc.thePlayer, p_78472_1_)
+				: 0.0F;
+
+		// What the dimension's ambient light leaks into the sky and block terms, per channel.
+		float sun = world.getSunBrightness(1.0F);
+		float sky = offset * (world.lastLightningBolt > 0 ? 1.0F : sun * 0.95F + 0.05F);
+		float sunlit = sky * (sun * 0.65F + 0.35F);
+		this.etfu$floorRed = etfu$ambientFloor(counterpart, 0, nightVision, sunlit + this.etfu$ambientTerm);
+		this.etfu$floorGreen = etfu$ambientFloor(counterpart, 1, nightVision, sunlit);
+		this.etfu$floorBlue = etfu$ambientFloor(counterpart, 2, nightVision, sky);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.1F))
+	private float etfu$modernFlickerFactor(float original) {
+		return this.etfu$modernBlockLight ? this.etfu$flickerFactor : original;
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 1.5F))
+	private float etfu$modernBlockFactor(float original) {
+		return this.etfu$modernBlockLight ? this.etfu$blockFactor : original;
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 0))
+	private float etfu$ambientFloorRed(float original) {
+		return this.etfu$floorRed;
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 1))
+	private float etfu$ambientFloorGreen(float original) {
+		return this.etfu$floorGreen;
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 2))
+	private float etfu$ambientFloorBlue(float original) {
+		return this.etfu$floorBlue;
+	}
+
+	@Redirect(method = "updateLightmap", at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/client/entity/EntityClientPlayerMP;isPotionActive(Lnet/minecraft/potion/Potion;)Z"))
+	private boolean etfu$skipVanillaNightVision(EntityClientPlayerMP player, Potion potion) {
+		return !this.etfu$modernNightVision && player.isPotionActive(potion);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 0))
+	private float etfu$dropAmbientScaleRed(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 1))
+	private float etfu$dropAmbientScaleGreen(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 2))
+	private float etfu$dropAmbientScaleBlue(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 3))
+	private float etfu$dropTrailingScaleRed(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 4))
+	private float etfu$dropTrailingScaleGreen(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.96F, ordinal = 5))
+	private float etfu$dropTrailingScaleBlue(float original) {
+		return etfu$dropBiasScale(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 3))
+	private float etfu$dropTrailingOffsetRed(float original) {
+		return etfu$dropTrailingOffset(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 4))
+	private float etfu$dropTrailingOffsetGreen(float original) {
+		return etfu$dropTrailingOffset(original);
+	}
+
+	@ModifyConstant(method = "updateLightmap", constant = @Constant(floatValue = 0.03F, ordinal = 5))
+	private float etfu$dropTrailingOffsetBlue(float original) {
+		return etfu$dropTrailingOffset(original);
+	}
+
+	@Inject(method = "updateLightmap", at = @At(value = "CONSTANT", args = "floatValue=0.96F", ordinal = 0))
+	private void etfu$modernBlockLightTint(float p_78472_1_, CallbackInfo ci,
+										   @Local(name = "f2") float skyTerm,
+										   @Local(name = "f3") float blockTerm,
+										   @Local(name = "f5") float sunTerm,
+										   @Local(name = "i") int index,
+										   @Local(name = "f6") LocalFloatRef blockGreen,
+										   @Local(name = "f7") LocalFloatRef blockBlue,
+										   @Local(name = "f9") LocalFloatRef green,
+										   @Local(name = "f10") LocalFloatRef blue) {
+		if (!this.etfu$modernBlockLight) {
+			return;
+		}
+
+		int level = index % 16;
+		float levelTerm = blockTerm - this.etfu$ambientTerm;
+		float g = levelTerm * ModernLightmap.BLOCK_TINT_CURVE[1][level];
+		float b = levelTerm * ModernLightmap.BLOCK_TINT_CURVE[2][level];
+
+		if (this.etfu$ambientColor == null) {
+			g += this.etfu$legacyGreen;
+			b += this.etfu$legacyBlue;
+		}
+
+		blockGreen.set(g);
+		blockBlue.set(b);
+		green.set(sunTerm + g);
+		blue.set(skyTerm + b);
+	}
+
+	@Unique
+	private float etfu$dropBiasScale(float original) {
+		return this.etfu$modernBlockLight ? 1.0F : original;
+	}
+
+	@Unique
+	private float etfu$dropTrailingOffset(float original) {
+		return this.etfu$modernBlockLight ? 0.0F : original;
+	}
+
+	@Unique
+	private float etfu$ambientFloor(boolean counterpart, int channel, float nightVisionBrightness, float leak) {
+		if (!counterpart) {
+			return 0.03F;
+		}
+		float nightVision = this.etfu$modernNightVision
+				? ModernLightmap.NIGHT_VISION[channel] * nightVisionBrightness
+				: 0.0F;
+		if (ConfigWorld.modernBlockLightTint) {
+			return this.etfu$ambientColor == null
+					? 0.03F
+					: Math.max(this.etfu$ambientColor[channel], nightVision) - leak;
+		}
+		return Math.max(0.03F, (nightVision - 0.03F) / ModernLightmap.BIAS);
+	}
+
+	@Unique
+	private static float etfu$vanillaGreen(float term) {
+		return term * ((term * 0.6F + 0.4F) * 0.6F + 0.4F);
+	}
+
+	@Unique
+	private static float etfu$vanillaBlue(float term) {
+		return term * (term * term * 0.6F + 0.4F);
+	}
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
@@ -58,7 +58,7 @@ public class MixinEntityRenderer {
 		float max = Math.max(r, Math.max(g, b));
 		if (max > 0.0F) {
 			float inverted = 1.0F - max;
-			float scaled = (float) (1.0F - Math.pow(inverted, 4));
+			float scaled = (float) (1.0F - (inverted*inverted*inverted*inverted));
 			float mix = 1.0F + gamma * (scaled / max - 1.0F);
 			r *= mix;
 			g *= mix;

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
@@ -1,12 +1,16 @@
 package ganymedes01.etfuturum.mixins.early.modernlightmap.client;
 
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+import ganymedes01.etfuturum.client.ModernLightmap;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.settings.GameSettings;
 import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -21,50 +25,51 @@ public class MixinEntityRenderer {
 	@Shadow
 	private Minecraft mc;
 
-	@Shadow
-	@Final
-	private int[] lightmapColors;
+	@Unique
+	private boolean etfu$hasModernCounterpart;
+
+	@Unique
+	private static float etfu$clamp(float value) {
+		return value < 0.0F ? 0.0F : Math.min(value, 1.0F);
+	}
+
+	@Inject(method = "updateLightmap", at = @At("HEAD"))
+	private void etfu$resolveModernGamma(float p_78472_1_, CallbackInfo ci) {
+		WorldClient world = this.mc.theWorld;
+		this.etfu$hasModernCounterpart = world != null && ModernLightmap.hasModernCounterpart(world.provider);
+	}
 
 	@Redirect(method = "updateLightmap", at = @At(value = "FIELD",
-			target = "Lnet/minecraft/client/settings/GameSettings;gammaSetting:F", opcode = Opcodes.GETFIELD))
-	private float etfu$skipPerChannelGamma(GameSettings settings) {
-		return 0.0F;
-	}
-
-	@Inject(method = "updateLightmap", at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/renderer/texture/DynamicTexture;updateDynamicTexture()V"))
-	private void etfu$applyModernGamma(float partialTicks, CallbackInfo ci) {
-		float gamma = this.mc.gameSettings.gammaSetting;
+			target = "Lnet/minecraft/client/settings/GameSettings;gammaSetting:F",
+			opcode = Opcodes.GETFIELD))
+	private float etfu$modernGamma(GameSettings settings,
+								   @Local(name = "f8") LocalFloatRef red,
+								   @Local(name = "f9") LocalFloatRef green,
+								   @Local(name = "f10") LocalFloatRef blue) {
+		float gamma = settings.gammaSetting;
+		if (!this.etfu$hasModernCounterpart) {
+			return gamma;
+		}
 		if (gamma <= 0.0F) {
-			return;
+			return 0.0F;
 		}
-		int[] colors = this.lightmapColors;
-		for (int i = 0; i < colors.length; i++) {
-			int color = colors[i];
-			int alpha = color >>> 24 & 255;
-			float r = ((color >> 16 & 255) / 255.0F - 0.03F) / 0.96F;
-			float g = ((color >> 8 & 255) / 255.0F - 0.03F) / 0.96F;
-			float b = ((color & 255) / 255.0F - 0.03F) / 0.96F;
+		float r = etfu$clamp(red.get());
+		float g = etfu$clamp(green.get());
+		float b = etfu$clamp(blue.get());
 
-			float max = Math.max(r, Math.max(g, b));
-			if (max > 0.0F) {
-				float inv = 1.0F - max;
-				float scaled = 1.0F - inv * inv * inv * inv;
-				float mix = 1.0F + gamma * (scaled / max - 1.0F);
-				r *= mix;
-				g *= mix;
-				b *= mix;
-			}
-
-			r = etfu$scaleAndClamp(r);
-			g = etfu$scaleAndClamp(g);
-			b = etfu$scaleAndClamp(b);
-			colors[i] = alpha << 24 | (int) (r * 255.0F) << 16 | (int) (g * 255.0F) << 8 | (int) (b * 255.0F);
+		float max = Math.max(r, Math.max(g, b));
+		if (max > 0.0F) {
+			float inverted = 1.0F - max;
+			float scaled = (float) (1.0F - Math.pow(inverted, 4));
+			float mix = 1.0F + gamma * (scaled / max - 1.0F);
+			r *= mix;
+			g *= mix;
+			b *= mix;
 		}
-	}
 
-	private static float etfu$scaleAndClamp(float v) {
-		v = v * 0.96F + 0.03F;
-		return v < 0.0F ? 0.0F : Math.min(v, 1.0F);
+		red.set(r);
+		green.set(g);
+		blue.set(b);
+		return 0.0F;
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernlightmap/client/MixinEntityRenderer.java
@@ -1,19 +1,18 @@
 package ganymedes01.etfuturum.mixins.early.modernlightmap.client;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
 import ganymedes01.etfuturum.client.ModernLightmap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
-import net.minecraft.client.settings.GameSettings;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
@@ -39,14 +38,13 @@ public class MixinEntityRenderer {
 		this.etfu$hasModernCounterpart = world != null && ModernLightmap.hasModernCounterpart(world.provider);
 	}
 
-	@Redirect(method = "updateLightmap", at = @At(value = "FIELD",
+	@ModifyExpressionValue(method = "updateLightmap", at = @At(value = "FIELD",
 			target = "Lnet/minecraft/client/settings/GameSettings;gammaSetting:F",
 			opcode = Opcodes.GETFIELD))
-	private float etfu$modernGamma(GameSettings settings,
+	private float etfu$modernGamma(float gamma,
 								   @Local(name = "f8") LocalFloatRef red,
 								   @Local(name = "f9") LocalFloatRef green,
 								   @Local(name = "f10") LocalFloatRef blue) {
-		float gamma = settings.gammaSetting;
 		if (!this.etfu$hasModernCounterpart) {
 			return gamma;
 		}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Too many pictures to really dump here. Please test yourself to see changes. A bit more sloppy than usual, and tried to support modded dims.

Anything lightmap/brightness related should auto-disable if a modded dim changes the lightmap in any way compared to the default 3 dims.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
