### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -255,7 +255,7 @@ public class EtFuturum {
 				((IInitAction) block.get()).preInitAction();
 			}
 		}
-		for (ModItems item : ModItems.values()) {
+		for (ModItems item : ModItems.VALUES) {
 			if (item.isEnabled() && item.get() instanceof IInitAction) {
 				((IInitAction) item.get()).preInitAction();
 			}
@@ -315,7 +315,7 @@ public class EtFuturum {
 				((IInitAction) block.get()).initAction();
 			}
 		}
-		for (ModItems item : ModItems.values()) {
+		for (ModItems item : ModItems.VALUES) {
 			if (item.isEnabled() && item.get() instanceof IInitAction) {
 				((IInitAction) item.get()).initAction();
 			}
@@ -422,7 +422,7 @@ public class EtFuturum {
 				((IInitAction) block.get()).postInitAction();
 			}
 		}
-		for (ModItems item : ModItems.values()) {
+		for (ModItems item : ModItems.VALUES) {
 			if (item.isEnabled() && item.get() instanceof IInitAction) {
 				((IInitAction) item.get()).postInitAction();
 			}
@@ -456,7 +456,7 @@ public class EtFuturum {
 				((IInitAction) block.get()).onLoadAction();
 			}
 		}
-		for (ModItems item : ModItems.values()) {
+		for (ModItems item : ModItems.VALUES) {
 			if (item.isEnabled() && item.get() instanceof IInitAction) {
 				((IInitAction) item.get()).onLoadAction();
 			}

--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -250,7 +250,7 @@ public class EtFuturum {
 			e.printStackTrace();
 		}
 
-		for (ModBlocks block : ModBlocks.values()) {
+		for (ModBlocks block : ModBlocks.VALUES) {
 			if (block.isEnabled() && block.get() instanceof IInitAction) {
 				((IInitAction) block.get()).preInitAction();
 			}
@@ -310,7 +310,7 @@ public class EtFuturum {
 
 	@EventHandler
 	public void init(FMLInitializationEvent event) {
-		for (ModBlocks block : ModBlocks.values()) {
+		for (ModBlocks block : ModBlocks.VALUES) {
 			if (block.isEnabled() && block.get() instanceof IInitAction) {
 				((IInitAction) block.get()).initAction();
 			}
@@ -417,7 +417,7 @@ public class EtFuturum {
 			}
 		}
 
-		for (ModBlocks block : ModBlocks.values()) {
+		for (ModBlocks block : ModBlocks.VALUES) {
 			if (block.isEnabled() && block.get() instanceof IInitAction) {
 				((IInitAction) block.get()).postInitAction();
 			}
@@ -451,7 +451,7 @@ public class EtFuturum {
 	@EventHandler
 	@SuppressWarnings("unchecked")
 	public void onLoadComplete(FMLLoadCompleteEvent e) {
-		for (ModBlocks block : ModBlocks.values()) {
+		for (ModBlocks block : ModBlocks.VALUES) {
 			if (block.isEnabled() && block.get() instanceof IInitAction) {
 				((IInitAction) block.get()).onLoadAction();
 			}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
