### PR TITLE
Fixed ETF furnace short overflow bug

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
@@ -129,7 +129,7 @@ public class TileEntityBlastFurnace extends TileEntity implements ISidedInventor
 		this.furnaceItemStacks = new ItemStack[this.getSizeInventory()];
 		Utils.loadItemStacksFromNBT(nbttaglist, this.furnaceItemStacks);
 
-		this.furnaceBurnTime = compound.getShort("BurnTime");
+		this.furnaceBurnTime = compound.getInteger("BurnTime");
 		this.furnaceCookTime = compound.getShort("CookTime");
 		this.currentItemBurnTime = getItemBurnTime(this.furnaceItemStacks[1]);
 
@@ -141,7 +141,7 @@ public class TileEntityBlastFurnace extends TileEntity implements ISidedInventor
 	@Override
 	public void writeToNBT(NBTTagCompound compound) {
 		super.writeToNBT(compound);
-		compound.setShort("BurnTime", (short) this.furnaceBurnTime);
+		compound.setInteger("BurnTime", this.furnaceBurnTime);
 		compound.setShort("CookTime", (short) this.furnaceCookTime);
 
 		compound.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
@@ -133,7 +133,7 @@ public class TileEntitySmoker extends TileEntity implements ISidedInventory {
 		this.furnaceItemStacks = new ItemStack[this.getSizeInventory()];
 		Utils.loadItemStacksFromNBT(nbttaglist, this.furnaceItemStacks);
 
-		this.furnaceBurnTime = compound.getShort("BurnTime");
+		this.furnaceBurnTime = compound.getInteger("BurnTime");
 		this.furnaceCookTime = compound.getShort("CookTime");
 		this.currentItemBurnTime = getItemBurnTime(this.furnaceItemStacks[1]);
 
@@ -145,7 +145,7 @@ public class TileEntitySmoker extends TileEntity implements ISidedInventory {
 	@Override
 	public void writeToNBT(NBTTagCompound compound) {
 		super.writeToNBT(compound);
-		compound.setShort("BurnTime", (short) this.furnaceBurnTime);
+		compound.setInteger("BurnTime", this.furnaceBurnTime);
 		compound.setShort("CookTime", (short) this.furnaceCookTime);
 
 		compound.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));


### PR DESCRIPTION
## Summary
Converting burn time to a Short when writing and reading NBT would cause an overflow bug with fuel over 32767 (many fuels in GT5), this would also confuse WAILA and the furnace renderer as the burn time would be negative. This also happens with vanilla furnaces, but is not a thing to fix in ETF.

Changes the "BurnTime" component in both the Smoker and Blast Furnace tile entities to use an Integer tag instead of a Short tag.

(fixes this bug for ETF but not for vanilla https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25273)

## Todo
Furnace mixin in another repo to fix vanilla furnaces (not for ETF)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
