### PR TITLE
Better deepslate failure log

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/api/DeepslateOreRegistry.java
+++ b/src/main/java/ganymedes01/etfuturum/api/DeepslateOreRegistry.java
@@ -197,8 +197,7 @@ public class DeepslateOreRegistry {
 				Block oreNorm = entry.getKey().getObject();
 				Block oreDeep = entry.getValue().getObject();
 				if (!ModRecipes.validateItems(oreNorm, oreDeep)) {
-					Logger.error("INVALID FURNACE RECIPE DETECTED: " + entry);
-					Logger.error("This means that a mod added INVALID items to the furnace registry!");
+					Logger.error("INVALID DEEPSLATE ORE MAPPING DETECTED: source=" + entry.getKey() + ", replacement=" + entry.getValue() + ". A block is air or unregistered.");
 				}
 
 				boolean saltyModOre = oreDeep.getClass().getName().toLowerCase().contains("saltymod");

--- a/src/main/java/ganymedes01/etfuturum/api/mappings/RegistryMapping.java
+++ b/src/main/java/ganymedes01/etfuturum/api/mappings/RegistryMapping.java
@@ -49,6 +49,15 @@ public class RegistryMapping<T> {
 		return object.hashCode(); // Do not hash meta so wildcards and metas all get placed into the same bucket
 	}
 
+	@Override
+	public String toString() {
+		String name = object instanceof Block ? Block.blockRegistry.getNameForObject(object) : Item.itemRegistry.getNameForObject(object);
+		if (name == null) {
+			name = "<unregistered:" + object.getClass().getName() + ">";
+		}
+		return name + ":" + (meta == OreDictionary.WILDCARD_VALUE ? "*" : meta);
+	}
+
 	/**
 	 * Returns a recycled RegistryMapping instance of the specified type. This does NOT CREATE A NEW INSTANCE!
 	 * This is used by things like deepslate registry as a key object without spamming the garbage collector with tons of new instances.

--- a/src/main/java/ganymedes01/etfuturum/blocks/ores/BlockDeepslateCopperOre.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/ores/BlockDeepslateCopperOre.java
@@ -12,7 +12,7 @@ import net.minecraftforge.oredict.OreDictionary;
 public class BlockDeepslateCopperOre extends BlockDeepslateOre implements IInitAction {
 
 	public BlockDeepslateCopperOre() {
-		super(ModBlocks.COPPER_ORE.get());
+		super(ModBlocks.COPPER_ORE.get(), ModBlocks.COPPER_ORE.isEnabled());
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
turn obscure 
```
INVALID FURNACE RECIPE DETECTED: ganymedes01.etfuturum.api.mappings.RegistryMapping@164681e0=ganymedes01.etfuturum.api.mappings.RegistryMapping@7b1991a8
```
into
```
INVALID DEEPSLATE ORE MAPPING DETECTED: source=<unregistered:ganymedes01.etfuturum.blocks.ores.BlockCopperOre>:0, replacement=etfuturum:deepslate_copper_ore:0. A block is air or unregistered.
```
Bonus point, issue fixed within this PR as well 😎 
  

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
