### PR TITLE
Backport modern chest connections

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -69,6 +69,9 @@ dependencies {
     }
 
     compileOnly('com.github.GTNewHorizons:Backhand:1.8.11:dev') {transitive = false}
+
+//    runtimeOnlyNonPublishable('com.falsepattern:chunkapi-mc1.7.10:0.8.4:dev')
+//    runtimeOnlyNonPublishable('com.falsepattern:endlessids-mc1.7.10:1.7.4:dev')
 }
 
 configurations.configureEach {

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
@@ -23,6 +23,7 @@ public class ConfigMixins extends ConfigBase {
 	public static boolean newBeaconSounds;
 	public static boolean hoeTilling;
 	public static boolean blockHopperInteraction;
+	public static boolean modernChestConnections;
 	public static boolean avoidDroppingItemsWhenClosing;
 	public static boolean enableSpectatorMode;
 	public static boolean enableElytra;
@@ -45,7 +46,7 @@ public class ConfigMixins extends ConfigBase {
 	public static boolean thinPanes;
 	public static boolean colorGrassBlockItemSides;
 	public static boolean enablePlayersSleepingPecentageGamerule;
-  public static boolean enableJumpClimbing;
+  	public static boolean enableJumpClimbing;
 	public static boolean worldSaveThumbnails;
 	public static boolean modernLoadingScreen;
 	public static boolean adjustedLiquidPhysics;
@@ -89,6 +90,7 @@ public class ConfigMixins extends ConfigBase {
 		enableSpectatorMode = getBoolean("enableSpectatorMode", catBackport, true, "VERY EXPERIMENTAL!\nModified Classes: net.minecraft.world.WorldSettings.GameType net.minecraft.entity.Entity net.minecraft.world.World net.minecraft.entity.player.EntityPlayer net.minecraft.network.NetHandlerPlayServer net.minecraft.entity.player.InventoryPlayer net.minecraft.inventory.ContainerChest\nModified Client Classes: net.minecraft.client.renderer.EntityRenderer net.minecraft.entity.player.EntityPlayer net.minecraft.client.renderer.WorldRenderer");
 		enableObservers = getBoolean("enableObservers", catBackport, true, "Modified Classes: net.minecraft.world.World net.minecraft.world.WorldServer");
 		blockHopperInteraction = getBoolean("blockHopperInteraction", catBackport, true, "Allows some blocks without tile entities (e.g. composters) to interact with hoppers. May still not interact with modded pipes.\nModified Classes: net.minecraft.tileentity.TileEntityHopper");
+		modernChestConnections = getBoolean("modernChestConnections", catBackport, true, "Allows deciding whether chests should be connected when placing. Requires EndlessIDs\nDisabling this will corrupt all existing chest connections created while this was enabled (not the items).");
 
 		enableNewElytraTakeoffLogic = getBoolean("enableNewElytraTakeoffLogic", catBackport, true, "When enabled, the 1.15+ elytra takeoff logic is used, when disabled, the 1.9-1.14 elytra takeoff logic is used.");
 		enableDoWeatherCycle = getBoolean("enableDoWeatherCycle", catBackport, true, "Add the doWeatherCycle game rule from 1.11+");

--- a/src/main/java/ganymedes01/etfuturum/core/utils/ChestDir.java
+++ b/src/main/java/ganymedes01/etfuturum/core/utils/ChestDir.java
@@ -1,0 +1,119 @@
+package ganymedes01.etfuturum.core.utils;
+
+import com.gtnewhorizon.gtnhlib.blockpos.BlockPos;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.joml.Vector3ic;
+
+public enum ChestDir {
+    NONE(new BlockPos(0, 0, 0)),
+    POS_Z(new BlockPos(0, 0, 1)),
+    NEG_Z(new BlockPos(0, 0, -1)),
+    POS_X(new BlockPos(1, 0, 0)),
+    NEG_X(new BlockPos(-1, 0, 0)),
+    ;
+
+    public static final ChestDir[] VALUES = values();
+    public static final ChestDir[] VALID_CONNECTIONS = { POS_Z, NEG_Z, POS_X, NEG_X };
+
+    private final BlockPos offset;
+
+    ChestDir(BlockPos offset) {
+        this.offset = offset;
+    }
+
+    /// @param meta `0b..._E???`
+    /// @return whether E is set
+    public static boolean hasConnectionMeta(int meta) {
+        return (meta & 0b1000) != 0;
+    }
+
+    /// @param meta `0b..._?CCC_E???`, where `C` are the connection bits
+    /// @return [ChestDir] from `CCC` if `E` is set, otherwise [NONE]
+    public static ChestDir fromConnectionMeta(int meta) {
+        if (!hasConnectionMeta(meta)) {
+            return NONE;
+        }
+        int ordinal = (meta & 0b111_0000) >> 4;
+        if (ordinal >= VALUES.length) {
+            return NONE;
+        }
+        return VALUES[ordinal];
+    }
+
+    /// Writes the [ChestDir] ordinal into `CCC`.<br>
+    /// Sets the modern connections enabled bit `E`.<br>
+    /// Leaves the rest of the bits unchanged.
+    ///
+    /// @param meta `0b..._?CCC_E???`
+    public int toConnectionMeta(int meta) {
+        return (meta & ~0b111_1000) | (ordinal() << 4) | 0b1000;
+    }
+
+    /// @param meta `0b..._?SSS`, where `SSS` is an ordinal of [ForgeDirection]
+    public static ChestDir fromSideMeta(int meta) {
+        return switch (meta & 0b111) {
+            case 2 -> POS_Z;
+            case 3 -> NEG_Z;
+            case 4 -> POS_X;
+            case 5 -> NEG_X;
+            default -> NONE;
+        };
+    }
+
+    /// Writes the ordinal of the [ForgeDirection] equivalent of this [ChestDir] into `SSS`.<br>
+    /// [NONE] is mapped to [ForgeDirection#UNKNOWN].<br>
+    /// Leaves the rest of the bits unchanged.
+    ///
+    /// @param meta `0b..._?SSS`
+    public int toSideMeta(int meta) {
+        int dirOrdinal = switch (this) {
+            case POS_Z -> 2;
+            case NEG_Z -> 3;
+            case POS_X -> 4;
+            case NEG_X -> 5;
+            default -> 0;
+        };
+        return (meta & ~0b111) | dirOrdinal;
+    }
+
+    /// Turns the connection dir 180°. [NONE] is not turned.
+    public ChestDir flip() {
+        return switch (this) {
+            case NONE -> NONE;
+            case POS_Z -> NEG_Z;
+            case NEG_Z -> POS_Z;
+            case POS_X -> NEG_X;
+            case NEG_X -> POS_X;
+        };
+    }
+
+    /// Turns the connection dir 90°. [NONE] is not turned.
+    public ChestDir turn() {
+        return switch (this) {
+            case NONE -> NONE;
+            case POS_Z -> NEG_X;
+            case NEG_X -> NEG_Z;
+            case NEG_Z -> POS_X;
+            case POS_X -> POS_Z;
+        };
+    }
+
+    /// @return whether `other` is orthogonal to `this`. [NONE] is only orthogonal to [NONE]
+    public boolean orthogonal(ChestDir other) {
+        ChestDir turn = other.turn();
+        return this == turn || this == turn.flip();
+    }
+
+    /// @return a unit vector in the direction of `this`, or the zero vector if `this` is [NONE]
+    public Vector3ic toOffset() {
+        return offset;
+    }
+
+    /// @return whether `this` is positive on its axis. [NONE] is not positive
+    public boolean isPos() {
+        return switch (this) {
+            case NONE, NEG_Z, NEG_X -> false;
+            case POS_Z, POS_X -> true;
+        };
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -2,7 +2,6 @@ package ganymedes01.etfuturum.mixinplugin;
 
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
-import ganymedes01.etfuturum.Tags;
 import ganymedes01.etfuturum.compat.CompatMisc;
 import ganymedes01.etfuturum.configuration.ConfigBase;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
@@ -220,6 +219,13 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 
 		if (ConfigMixins.blockHopperInteraction) {
 			mixins.add("blockinventories.MixinTileEntityHopper");
+		}
+
+		if (ConfigMixins.modernChestConnections && loadedCoreMods.contains("com.falsepattern.endlessids.asm.EndlessIDsCore")) {
+			mixins.add("modernchestconnections.AccessorTileEntityChest");
+			mixins.add("modernchestconnections.MixinBlockChest");
+			mixins.add("modernchestconnections.MixinTileEntityChest");
+			mixins.add("modernchestconnections.MixinTileEntityChestRenderer");
 		}
 
 		if (ConfigMixins.collidedThrowableFix) {

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/AccessorTileEntityChest.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/AccessorTileEntityChest.java
@@ -1,0 +1,11 @@
+package ganymedes01.etfuturum.mixins.early.modernchestconnections;
+
+import net.minecraft.tileentity.TileEntityChest;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(TileEntityChest.class)
+public interface AccessorTileEntityChest {
+    @Invoker("func_145978_a")
+    void etfu$updateAdjacentChest(TileEntityChest tileEntityChest, int dir);
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinBlockChest.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinBlockChest.java
@@ -1,0 +1,330 @@
+package ganymedes01.etfuturum.mixins.early.modernchestconnections;
+
+import ganymedes01.etfuturum.core.utils.ChestDir;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockChest;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryLargeChest;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.joml.Vector3ic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockChest.class)
+public class MixinBlockChest extends Block {
+    @Shadow
+    private static boolean func_149953_o(World world, int x, int y, int z) {throw new UnsupportedOperationException("Implemented via mixin");}
+
+    protected MixinBlockChest(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Override
+    public int onBlockPlaced(World world, int x, int y, int z, int side, float subX, float subY, float subZ, int meta) {
+        int oldMeta = super.onBlockPlaced(world, x, y, z, side, subX, subY, subZ, meta);
+        int newMeta = ChestDir.NONE.toConnectionMeta(oldMeta);
+
+        ChestDir conn = ChestDir.fromSideMeta(side);
+        // automatic connections depend on placer state
+        if (conn == ChestDir.NONE) return newMeta;
+
+        // horizontal side clicked, connect to it if it's a connectable chest
+        Vector3ic off = conn.toOffset();
+        Block adjacentBlock = world.getBlock(x + off.x(), y + off.y(), z + off.z());
+        // no adjacent chest to connect to
+        if (adjacentBlock != this) return newMeta;
+
+        int adjacentMeta = world.getBlockMetadata(x + off.x(), y + off.y(), z + off.z());
+        // only connect to not already connected chests
+        if (ChestDir.fromConnectionMeta(adjacentMeta) == ChestDir.NONE) {
+            return conn.toConnectionMeta(newMeta);
+        }
+
+        return newMeta;
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing block connection logic
+     */
+    @Overwrite
+    public void onBlockAdded(World world, int x, int y, int z) {
+        super.onBlockAdded(world, x, y, z);
+        int meta = world.getBlockMetadata(x, y, z);
+        if (!ChestDir.hasConnectionMeta(meta)) {
+            // we were not placed by a user, default to unconnected modern chest
+            int newMeta = ChestDir.NONE.toConnectionMeta(meta);
+            world.setBlockMetadataWithNotify(x, y, z, newMeta, 0);
+        }
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing block connection logic
+     */
+    @Overwrite
+    public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase placer, ItemStack item) {
+        int explicitMeta = world.getBlockMetadata(x, y, z);
+
+        int quadrant = MathHelper.floor_double((double) (placer.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+        ChestDir dir = switch (quadrant) {
+            case 0 -> ChestDir.POS_Z;
+            case 1 -> ChestDir.NEG_X;
+            case 2 -> ChestDir.NEG_Z;
+            case 3 -> ChestDir.POS_X;
+            default -> ChestDir.NONE;
+        };
+
+        int dirExplicitMeta = dir.toSideMeta(explicitMeta);
+        etfu$tryConnectOnPlacedBy(world, x, y, z, placer, dirExplicitMeta);
+
+        if (item.hasDisplayName()) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            ((TileEntityChest) tile).func_145976_a(item.getDisplayName());
+        }
+    }
+
+    // always writes the meta to world and notifies neighbors of affected adjacent
+    @Unique
+    private void etfu$tryConnectOnPlacedBy(World world, int x, int y, int z, EntityLivingBase placer, int explicitMeta) {
+        // try explicit connect
+        ChestDir explicitConn = ChestDir.fromConnectionMeta(explicitMeta);
+        if (explicitConn != ChestDir.NONE) {
+            if (etfu$tryConnect(world, x, y, z, explicitConn, explicitMeta)) return;
+        }
+
+        int meta = ChestDir.NONE.toConnectionMeta(explicitMeta);
+
+        // if sneaking, don't connect automatically
+        if (placer.isSneaking()) {
+            world.setBlockMetadataWithNotify(x, y, z, meta, 3);
+            return;
+        }
+
+        // try automatic connect
+        for (ChestDir conn : ChestDir.VALID_CONNECTIONS) {
+            if (etfu$tryConnect(world, x, y, z, conn, meta)) return;
+        }
+
+        // can't connect to anything, just set the given meta
+        world.setBlockMetadataWithNotify(x, y, z, meta, 3);
+    }
+
+    @Unique
+    private boolean etfu$tryConnect(World world, int x, int y, int z, ChestDir conn, int baseMeta) {
+        Vector3ic off = conn.toOffset();
+        int cx = x + off.x();
+        int cy = y + off.y();
+        int cz = z + off.z();
+
+        Block adjBlock = world.getBlock(cx, cy, cz);
+        if (adjBlock != this) return false;
+
+        int oldAdjMeta = world.getBlockMetadata(cx, cy, cz);
+        // check if candidate already connected
+        ChestDir adjConn = etfu$getConnection(world, cx, cy, cz, oldAdjMeta, conn.flip());
+        if (adjConn != ChestDir.NONE) return false;
+
+        // connect to valid connection target chest
+        ChestDir otherConn = conn.flip();
+        int meta = conn.toConnectionMeta(baseMeta);
+        int adjMeta = otherConn.toConnectionMeta(oldAdjMeta);
+
+        int newMeta = etfu$updateFacingMeta(world, conn, meta, adjMeta, x, y, z);
+        int newAdjMeta = etfu$updateFacingMeta(world, otherConn, adjMeta, newMeta, cx, cy, cz);
+
+        world.setBlockMetadataWithNotify(x, y, z, newMeta, 2);
+        world.setBlockMetadataWithNotify(cx, cy, cz, newAdjMeta, 3);
+        etfu$notifyBlock(world, x, y, z, this);
+        return true;
+    }
+
+    @Inject(method = "onNeighborBlockChange", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockContainer;onNeighborBlockChange(Lnet/minecraft/world/World;IIILnet/minecraft/block/Block;)V"))
+    private void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor, CallbackInfo ci) {
+        int meta = world.getBlockMetadata(x, y, z);
+
+        ChestDir conn = ChestDir.fromConnectionMeta(meta);
+        // we don't care about neighbors
+        if (conn == ChestDir.NONE) return;
+
+        Vector3ic off = conn.toOffset();
+        Block adjBlock = world.getBlock(x + off.x(), y + off.y(), z + off.z());
+        if (adjBlock == this) {
+            int adjMeta = world.getBlockMetadata(x + off.x(), y + off.y(), z + off.z());
+            // connected chest is also connected to us, we're fine
+            if (ChestDir.fromConnectionMeta(adjMeta) == conn.flip()) return;
+        }
+
+        // connected to a non-chest or a chest that's not connected to us, reset connection
+        int newMeta = ChestDir.NONE.toConnectionMeta(meta);
+        world.setBlockMetadataWithNotify(x, y, z, newMeta, 3);
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing inventory connection logic
+     */
+    @Overwrite
+    public IInventory func_149951_m/*getInventory*/(World world, int x, int y, int z) {
+        int meta = world.getBlockMetadata(x, y, z);
+
+        TileEntityChest tile = (TileEntityChest) world.getTileEntity(x, y, z);
+        if (tile == null || etfu$isChestBlocked(world, x, y, z)) return null;
+
+        // find valid connection target
+        ChestDir conn = etfu$getConnection(world, x, y, z, meta, null);
+        // single chest
+        if (conn == ChestDir.NONE) return tile;
+
+        // check for broken connection
+        if (ChestDir.hasConnectionMeta(meta)) {
+            Vector3ic off = conn.toOffset();
+
+            Block adjBlock = world.getBlock(x + off.x(), y + off.y(), z + off.z());
+            // we're connected to a chest, but there is no chest, broken state
+            if (adjBlock != this) return null;
+
+            int adjMeta = world.getBlockMetadata(x + off.x(), y + off.y(), z + off.z());
+            // we're connected to a chest, but it's not connected to us, broken state
+            if (ChestDir.fromConnectionMeta(adjMeta) != conn.flip()) return null;
+        }
+
+        Vector3ic off = conn.toOffset();
+
+        // blocked
+        if (etfu$isChestBlocked(world, x + off.x(), y + off.y(), z + off.z())) return null;
+
+        TileEntityChest adjTile = (TileEntityChest) world.getTileEntity(x + off.x(), y + off.y(), z + off.z());
+        // broken TE
+        if (adjTile == null) return null;
+
+        IInventory upper = conn.isPos() ? tile : adjTile;
+        IInventory lower = conn.isPos() ? adjTile : tile;
+        return new InventoryLargeChest("container.chestDouble", upper, lower);
+    }
+
+    @Unique
+    private boolean etfu$isChestBlocked(World world, int x, int y, int z) {
+        if (world.isSideSolid(x, y + 1, z, ForgeDirection.DOWN)) return true;
+        return func_149953_o/*blockedBySittingOcelot*/(world, x, y, z);
+    }
+
+    /**
+     * @author kurrycat
+     * @reason modern chests can always be placed
+     */
+    @Overwrite
+    public boolean canPlaceBlockAt(World world, int x, int y, int z) {
+        return true;
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing block connection logic
+     */
+    @Overwrite
+    public void func_149954_e/*updateChestFacing*/(World world, int x, int y, int z) {
+        if (world.isRemote) return;
+
+        int meta = world.getBlockMetadata(x, y, z);
+
+        ChestDir conn = etfu$getConnection(world, x, y, z, meta, null);
+        // single chest
+        if (conn == ChestDir.NONE) return;
+
+        Vector3ic off = conn.toOffset();
+        int adjMeta = world.getBlockMetadata(x + off.x(), y + off.y(), z + off.z());
+        int newMeta = etfu$updateFacingMeta(world, conn, meta, adjMeta, x, y, z);
+        world.setBlockMetadataWithNotify(x, y, z, newMeta, 3);
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing block connection logic
+     */
+    @Overwrite
+    public void setBlockBoundsBasedOnState(IBlockAccess world, int x, int y, int z) {
+        int meta = world.getBlockMetadata(x, y, z);
+
+        ChestDir conn = etfu$getConnection(world, x, y, z, meta, null);
+        switch (conn) {
+            case NONE -> setBlockBounds(0.0625F, 0.0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);
+            case POS_Z -> setBlockBounds(0.0625F, 0.0F, 0.0625F, 0.9375F, 0.875F, 1.0F);
+            case NEG_Z -> setBlockBounds(0.0625F, 0.0F, 0.0F, 0.9375F, 0.875F, 0.9375F);
+            case POS_X -> setBlockBounds(0.0625F, 0.0F, 0.0625F, 1.0F, 0.875F, 0.9375F);
+            case NEG_X -> setBlockBounds(0.0F, 0.0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);
+        }
+    }
+
+    @Unique
+    private ChestDir etfu$getConnection(IBlockAccess world, int x, int y, int z, int meta, ChestDir skip) {
+        if (ChestDir.hasConnectionMeta(meta)) return ChestDir.fromConnectionMeta(meta);
+
+        // find legacy connection
+        for (ChestDir conn : ChestDir.VALID_CONNECTIONS) {
+            if (conn == skip) continue;
+
+            Vector3ic off = conn.toOffset();
+
+            Block adjBlock = world.getBlock(x + off.x(), y + off.y(), z + off.z());
+            if (adjBlock != this) continue;
+
+            int adjMeta = world.getBlockMetadata(x + off.x(), y + off.y(), z + off.z());
+            // invalid legacy connection target
+            if (ChestDir.hasConnectionMeta(adjMeta)) continue;
+
+            // valid connection target
+            return conn;
+        }
+        return ChestDir.NONE;
+    }
+
+    // only reads blocks from world, no meta
+    @Unique
+    private int etfu$updateFacingMeta(IBlockAccess world, ChestDir conn, int meta, int adjMeta, int x, int y, int z) {
+        ChestDir facing = ChestDir.fromSideMeta(meta);
+        // facing is already correct
+        if (facing.orthogonal(conn)) return meta;
+
+        ChestDir connFacing = ChestDir.fromSideMeta(adjMeta);
+        // wrong facing, but conn is correct, so take their facing
+        if (connFacing.orthogonal(conn)) return connFacing.toSideMeta(meta);
+
+        // prefer the side with less opaque blocks
+        Vector3ic r = conn.turn().toOffset();
+        Vector3ic l = conn.turn().flip().toOffset();
+
+        Block tr = world.getBlock(x + r.x(), y + r.y(), z + r.z());
+        Block tl = world.getBlock(x + l.x(), y + l.y(), z + l.z());
+
+        Vector3ic o = conn.toOffset();
+        Block cr = world.getBlock(x + o.x() + r.x(), y + o.y() + r.y(), z + o.z() + r.z());
+        Block cl = world.getBlock(x + o.x() + l.x(), y + o.y() + l.y(), z + o.z() + l.z());
+
+        int rOpaque = (tr.func_149730_j() ? 1 : 0) + (cr.func_149730_j() ? 1 : 0);
+        int lOpaque = (tl.func_149730_j() ? 1 : 0) + (cl.func_149730_j() ? 1 : 0);
+
+        ChestDir newFacing = rOpaque <= lOpaque ? conn.turn().flip() : conn.turn();
+        return newFacing.toSideMeta(meta);
+    }
+
+    @Unique
+    private void etfu$notifyBlock(World world, int x, int y, int z, Block block) {
+        Chunk chunk = world.getChunkFromBlockCoords(x, z);
+        world.markAndNotifyBlock(x, y, z, chunk, block, block, 1);
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinTileEntityChest.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinTileEntityChest.java
@@ -1,0 +1,140 @@
+package ganymedes01.etfuturum.mixins.early.modernchestconnections;
+
+import ganymedes01.etfuturum.core.utils.ChestDir;
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import org.joml.Vector3ic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityChest.class)
+public abstract class MixinTileEntityChest extends TileEntity {
+    @Shadow
+    public boolean adjacentChestChecked;
+
+    @Shadow
+    public TileEntityChest adjacentChestZNeg;
+
+    @Shadow
+    public TileEntityChest adjacentChestXPos;
+
+    @Shadow
+    public TileEntityChest adjacentChestXNeg;
+
+    @Shadow
+    public TileEntityChest adjacentChestZPos;
+
+    @Inject(method = "invalidate", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntity;invalidate()V", shift = At.Shift.AFTER))
+    private void updateAdjacent(CallbackInfo ci) {
+        if (worldObj == null) return;
+
+        TileEntityChest self = (TileEntityChest) (Object) this;
+        for (ChestDir conn : ChestDir.VALID_CONNECTIONS) {
+            Vector3ic off = conn.toOffset();
+            int adjX = xCoord + off.x();
+            int adjY = yCoord + off.y();
+            int adjZ = zCoord + off.z();
+
+            Block adjBlock = worldObj.getBlock(adjX, adjY, adjZ);
+            if (adjBlock != getBlockType()) continue;
+
+            TileEntityChest adjTile = (TileEntityChest) worldObj.getTileEntity(adjX, adjY, adjZ);
+            if (adjTile == null) continue;
+
+            int dir = etfu$adjacentUpdateDir(conn);
+            ((AccessorTileEntityChest) adjTile).etfu$updateAdjacentChest(self, dir);
+        }
+    }
+
+    /**
+     * @author kurrycat
+     * @reason replace existing block connection logic
+     */
+    @Overwrite
+    public void checkForAdjacentChests() {
+        if (adjacentChestChecked) return;
+
+        adjacentChestChecked = true;
+        adjacentChestZNeg = null;
+        adjacentChestXPos = null;
+        adjacentChestXNeg = null;
+        adjacentChestZPos = null;
+
+        if (worldObj == null) return;
+        if (isInvalid()) return;
+
+        int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
+        if (ChestDir.hasConnectionMeta(meta)) {
+            // only try to link connected chest
+            ChestDir conn = ChestDir.fromConnectionMeta(meta);
+            if (conn == ChestDir.NONE) return;
+
+            TileEntityChest adjTile = etfu$getConnectedChestInDir(conn, meta);
+            if (adjTile != null) {
+                etfu$linkToChest(conn, adjTile);
+            }
+        } else {
+            // try to link to first possible legacy chest connection
+            for (ChestDir conn : ChestDir.VALID_CONNECTIONS) {
+                TileEntityChest adjTile = etfu$getConnectedChestInDir(conn, meta);
+                if (adjTile != null) {
+                    etfu$linkToChest(conn, adjTile);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Unique
+    private TileEntityChest etfu$getConnectedChestInDir(ChestDir dir, int meta) {
+        Vector3ic off = dir.toOffset();
+        int adjX = xCoord + off.x();
+        int adjY = yCoord + off.y();
+        int adjZ = zCoord + off.z();
+
+        Block adjBlock = worldObj.getBlock(adjX, adjY, adjZ);
+        if (adjBlock != getBlockType()) return null;
+
+        int adjMeta = worldObj.getBlockMetadata(adjX, adjY, adjZ);
+        // only connect to modern chests that are connected to us
+        if (ChestDir.hasConnectionMeta(meta) && ChestDir.fromConnectionMeta(adjMeta) != dir.flip()) return null;
+        // if we're legacy, connect to any non-modern chest
+        if (!ChestDir.hasConnectionMeta(meta) && ChestDir.hasConnectionMeta(adjMeta)) return null;
+
+        return (TileEntityChest) worldObj.getTileEntity(adjX, adjY, adjZ);
+    }
+
+    @Unique
+    private void etfu$linkToChest(ChestDir conn, TileEntityChest tile) {
+        etfu$setAdjacentChest(conn, tile);
+        int dir = etfu$adjacentUpdateDir(conn);
+        ((AccessorTileEntityChest) tile).etfu$updateAdjacentChest((TileEntityChest) (Object) this, dir);
+    }
+
+    @Unique
+    private void etfu$setAdjacentChest(ChestDir dir, TileEntityChest tile) {
+        switch (dir) {
+            case NEG_Z -> adjacentChestZNeg = tile;
+            case POS_X -> adjacentChestXPos = tile;
+            case POS_Z -> adjacentChestZPos = tile;
+            case NEG_X -> adjacentChestXNeg = tile;
+        }
+    }
+
+    @Unique
+    private int etfu$adjacentUpdateDir(ChestDir dir) {
+        return switch (dir) {
+            case NEG_Z -> 0;
+            case POS_X -> 1;
+            case POS_Z -> 2;
+            case NEG_X -> 3;
+            case NONE -> throw new AssertionError();
+        };
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinTileEntityChestRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/modernchestconnections/MixinTileEntityChestRenderer.java
@@ -1,0 +1,14 @@
+package ganymedes01.etfuturum.mixins.early.modernchestconnections;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.client.renderer.tileentity.TileEntityChestRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(TileEntityChestRenderer.class)
+public class MixinTileEntityChestRenderer {
+    @ModifyExpressionValue(method = "renderTileEntityAt(Lnet/minecraft/tileentity/TileEntityChest;DDDF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntityChest;getBlockMetadata()I"))
+    private int onlyUseVanillaBitsForRendering(int original) {
+        return original & 0b111;
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Backports the modern chest placement behaviour, chests do not block other chests from being placed anymore.
The exact behaviour when placing a chest is now (in this priority):
- placing a chest on the side of another single chest connects it to that chest
- placing a chest while sneaking prevents it from being connected to other chests
- placing it normally automatically connects it to at most one adjacent single chest

https://github.com/user-attachments/assets/6da3132f-da43-4ac5-b0f2-15947bd173bc

This feature requires EndlessIDs, as chests now require 7 bits of meta.
The way this is implemented is that chests now have two modes.
Legacy chests, marked with bit 4 == 0 (vanilla chest rotation only uses 3 bits, so in vanilla this is always 0) behave basically exactly the same as old vanilla chests, but they don't connect to modern chests.
Modern chests, marked with bit 4 == 1, store the in world direction (+-X/+-Z) in which have a connection in meta. Because chests can only connect on one side at most, but they also can be unconnected, thats 5 states, so 3 bits.
Placing a chest always places a modern chest, and also connects it using the rules above. 
`setBlock()`ing a chest also always places a modern chest. The reason for this is that every type of chest is now not blocked anymore by adjacent double chests, which means that mods relying on `canPlaceBlockAt()` would create bugged vanilla triple chests if `setBlock()` would place legacy chests.
Placing a modern chest, so that it would connect with a legacy chest, converts that legacy chest into a modern chest.

Because modern chests' meta value is now not *only* their facing, some mods do not work correctly with it. Keeping legacy chests makes this less of a problem, but any mod that simply overwrites the meta of chests (to turn them for example) without keeping the extra bits will cause problems. 
This includes:
- GT wrenches / mallets: https://github.com/GTNewHorizons/GT5-Unofficial/pull/8013
- Dolly: https://github.com/GTNewHorizons/Jabba/pull/54
- ... (there are probably more)

These will need to be fixed independently, but this should often be possible without even an optional dep on EFR.
Because this is not done yet, i made this a draft PR. But the feature itself should work perfectly fine in vanilla, so maybe merging this and simply disabling it in the pack for now would also be an idea, if thats the wish.

Mods extending BlockChest, and especially the Chest TESR can also be a problem:
- Twilight Forest chests: https://github.com/GTNewHorizons/twilightforest/pull/157
- ... (there may be more)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
