### PR TITLE
fix world preview contamination

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/client/SpawnChunkProgress.java
+++ b/src/main/java/ganymedes01/etfuturum/client/SpawnChunkProgress.java
@@ -77,4 +77,8 @@ public class SpawnChunkProgress {
     private static long key(int x, int z) {
         return (long) x & 4294967295L | ((long) z & 4294967295L) << 32;
     }
+
+    public static boolean isActive() {
+        return active;
+    }
 }

--- a/src/main/java/ganymedes01/etfuturum/client/loading/LoadingScreenWorldGenTracker.java
+++ b/src/main/java/ganymedes01/etfuturum/client/loading/LoadingScreenWorldGenTracker.java
@@ -6,8 +6,8 @@ import net.minecraft.world.chunk.Chunk;
 public class LoadingScreenWorldGenTracker {
 
     public static void markTerrain(int chunkX, int chunkZ, Chunk chunk) {
-        // populate/loadChunk fire during normal play too, skip unless the loading screen is up
-        if (!LoadingScreenStateTracker.isActive()) {
+        // Skip populate/loadChunk fires after spawn progress is complete. It can happen even during normal play
+        if (!SpawnChunkProgress.isActive()) {
             return;
         }
         SpawnChunkProgress.markPopulated(chunkX, chunkZ);


### PR DESCRIPTION
## Summary

I noticed two imperfections in world preview:
1) the preview is generated with occasional gaps along the way
2) at the very end of world loading, right before you enter the world, you get a batch of randomly changed chunks, which i called contamination

I haven't tracked down the first one, but I solved the second nastier problem.

Before:
| First load | Second load |
| - | - |
| <img width="624" height="381" alt="image" src="https://github.com/user-attachments/assets/198a0dc7-111e-4d6f-b288-3a4c12149c95" /> | <img width="544" height="335" alt="image" src="https://github.com/user-attachments/assets/01c6c4d9-bbd3-4246-8bea-c946cda55432" /> |

After:
| First load | Second load |
| - | - |
| <img width="601" height="363" alt="image" src="https://github.com/user-attachments/assets/ed93bb98-f1b0-45d7-82d6-34e5c9d13eac" /> | <img width="578" height="355" alt="image" src="https://github.com/user-attachments/assets/150837bb-5201-4e5a-b447-a01dc32845ed" /> |


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
